### PR TITLE
feat: implement agentic and workflow execution modes with correspondi…

### DIFF
--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -50,6 +50,18 @@
 
 export * from "./src/compose.ts";
 
+// Plugin system
+export type {
+  AgentToolRegistrationContext,
+  ComposedTool,
+  ComposeEndContext,
+  ComposeStartContext,
+  FinalizeContext,
+  ToolConfig,
+  ToolPlugin,
+  TransformContext,
+} from "./src/plugin-types.ts";
+
 export * from "./src/utils/common/env.ts";
 export * from "./src/utils/common/json.ts";
 export * from "./src/utils/common/mcp.ts";

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -17,14 +17,13 @@ import { parseTags } from "@mcpc/utils";
 import { composeMcpDepTools } from "./utils/common/mcp.ts";
 import type { ComposeDefinition } from "./set-up-mcp-compose.ts";
 import type { JSONSchema, ToolCallback } from "./types.ts";
-import { registerAgenticTool } from "./executors/agentic/agentic-tool-registrar.ts";
-import { registerAgenticWorkflowTool } from "./executors/workflow/workflow-tool-registrar.ts";
 import { processToolTags } from "./utils/common/tool-tag-processor.ts";
 import { getBuiltInPlugins } from "./plugins/built-in/index.ts";
 import { createLogger } from "./utils/logger.ts";
 
 // Import plugin types and utilities
 import type { ComposedTool, ToolConfig, ToolPlugin } from "./plugin-types.ts";
+import type { ExecutionMode } from "./prompts/types.ts";
 import { sortPluginsByOrder, validatePlugins } from "./plugin-utils.ts";
 
 // Import new manager modules
@@ -343,7 +342,7 @@ export class ComposableMCPServer extends Server {
    */
   private async processToolsWithPlugins(
     externalTools: Record<string, ComposedTool>,
-    mode: "agentic" | "agentic_workflow",
+    mode: ExecutionMode,
   ): Promise<void> {
     const { processToolsWithPlugins: processTools } = await import(
       "./utils/compose-helpers.ts"
@@ -595,30 +594,29 @@ export class ComposableMCPServer extends Server {
       this,
     );
 
-    switch (options.mode ?? "agentic") {
-      case "agentic":
-        registerAgenticTool(this, {
-          description,
-          name,
-          allToolNames,
-          depGroups,
-          toolNameToDetailList,
-          sampling: options.sampling,
-        });
-        break;
-      case "agentic_workflow":
-        registerAgenticWorkflowTool(this, {
-          description,
-          name,
-          allToolNames,
-          depGroups,
-          toolNameToDetailList,
-          predefinedSteps: options.steps,
-          sampling: options.sampling,
-          ensureStepActions: options.ensureStepActions,
-          toolNameToIdMapping,
-        });
-        break;
+    const mode = options.mode ?? "agentic";
+    const context = {
+      server: this,
+      name,
+      description,
+      mode,
+      allToolNames,
+      toolNameToDetailList,
+      depGroups,
+      toolNameToIdMapping,
+      publicToolNames,
+      hiddenToolNames,
+      options,
+    };
+
+    // Trigger registerAgentTool hook - last plugin wins
+    const handled = await this.pluginManager.triggerRegisterAgentTool(context);
+
+    if (!handled) {
+      throw new Error(
+        `No plugin registered to handle execution mode "${mode}". ` +
+          `Did you override the default mode plugin, but in the wrong way?`,
+      );
     }
   }
 }

--- a/packages/core/src/executors/agentic/agentic-executor.ts
+++ b/packages/core/src/executors/agentic/agentic-executor.ts
@@ -154,6 +154,7 @@ export class AgenticExecutor {
             type: "text",
             text: CompiledPrompts.planningPrompt({
               currentAction: actionName,
+              toolName: this.name,
             }),
           });
         }
@@ -209,6 +210,7 @@ export class AgenticExecutor {
               type: "text",
               text: CompiledPrompts.planningPrompt({
                 currentAction: actionName,
+                toolName: this.name,
               }),
             });
           }

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -6,6 +6,7 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolCallback } from "./types.ts";
 import type { ComposableMCPServer } from "./compose.ts";
+import type { ExecutionMode } from "./prompts/types.ts";
 
 export interface ComposedTool extends Tool {
   execute: ToolCallback;
@@ -24,7 +25,7 @@ export interface ToolPlugin {
   enforce?: "pre" | "post";
 
   /** Apply plugin conditionally based on mode */
-  apply?: "agentic" | "workflow" | ((mode: string) => boolean);
+  apply?: ExecutionMode | ((mode: string) => boolean);
 
   /** Plugin dependencies - names of plugins that must be loaded first */
   dependencies?: string[];
@@ -47,6 +48,15 @@ export interface ToolPlugin {
   finalizeComposition?: (
     tools: Record<string, ComposedTool>,
     context: FinalizeContext,
+  ) => void | Promise<void>;
+
+  /**
+   * Called to register the final agent tool (execution mode).
+   * If multiple plugins implement this, the last one wins.
+   * Use this to implement custom execution modes.
+   */
+  registerAgentTool?: (
+    context: AgentToolRegistrationContext,
   ) => void | Promise<void>;
 
   /** Called after composition is complete - for logging and cleanup */
@@ -84,7 +94,7 @@ export interface CompositionInfo {
 export interface ComposeStartContext {
   serverName: string;
   description: string;
-  mode: "agentic" | "agentic_workflow";
+  mode: ExecutionMode;
   server: ComposableMCPServer;
   /** All available tool names before composition */
   availableTools: string[];
@@ -94,7 +104,7 @@ export interface ComposeStartContext {
 export interface TransformContext {
   toolName: string;
   server: ComposableMCPServer;
-  mode: "agentic" | "agentic_workflow";
+  mode: ExecutionMode;
   /** Original tool definition before any transformations */
   originalTool: ComposedTool;
   /** Index of current transformation (how many plugins have processed this tool) */
@@ -104,17 +114,38 @@ export interface TransformContext {
 /** Context for finalizeComposition hook */
 export interface FinalizeContext {
   serverName: string;
-  mode: "agentic" | "agentic_workflow";
+  mode: ExecutionMode;
   server: ComposableMCPServer;
   /** Names of all composed tools */
   toolNames: string[];
+}
+
+/** Context for registerAgentTool hook - implements custom execution modes */
+export interface AgentToolRegistrationContext {
+  server: ComposableMCPServer;
+  name: string;
+  description: string;
+  mode: ExecutionMode | string;
+  allToolNames: string[];
+  toolNameToDetailList: [string, ComposedTool][];
+  depGroups: Record<string, unknown>;
+  toolNameToIdMapping?: Map<string, string>;
+  publicToolNames: string[];
+  hiddenToolNames: string[];
+  options: {
+    mode?: string;
+    sampling?: boolean | { maxIterations?: number; summarize?: boolean };
+    steps?: Array<{ description: string; actions: string[] }>;
+    ensureStepActions?: string[];
+    [key: string]: unknown;
+  };
 }
 
 /** Context for composeEnd hook */
 export interface ComposeEndContext {
   toolName: string | null;
   pluginNames: string[];
-  mode: "agentic" | "agentic_workflow";
+  mode: ExecutionMode;
   server: ComposableMCPServer;
   /** Composition statistics - simplified */
   stats: {

--- a/packages/core/src/plugin-utils.ts
+++ b/packages/core/src/plugin-utils.ts
@@ -15,12 +15,12 @@ const pluginCache = new Map<string, ToolPlugin>();
  */
 export function shouldApplyPlugin(
   plugin: ToolPlugin,
-  mode: "agentic" | "agentic_workflow",
+  mode: string,
 ): boolean {
   if (!plugin.apply) return true;
 
   if (typeof plugin.apply === "string") {
-    return mode.includes(plugin.apply);
+    return mode === plugin.apply;
   }
 
   if (typeof plugin.apply === "function") {
@@ -112,6 +112,7 @@ export function isValidPlugin(plugin: unknown): plugin is ToolPlugin {
     typeof p.composeStart === "function" ||
     typeof p.transformTool === "function" ||
     typeof p.finalizeComposition === "function" ||
+    typeof p.registerAgentTool === "function" ||
     typeof p.composeEnd === "function" ||
     typeof p.transformInput === "function" ||
     typeof p.transformOutput === "function" ||

--- a/packages/core/src/plugins/built-in/index.ts
+++ b/packages/core/src/plugins/built-in/index.ts
@@ -6,11 +6,15 @@
 export { createConfigPlugin } from "./config-plugin.ts";
 export { createToolNameMappingPlugin } from "./tool-name-mapping-plugin.ts";
 export { createLoggingPlugin } from "./logging-plugin.ts";
+export { createAgenticModePlugin } from "./mode-agentic-plugin.ts";
+export { createWorkflowModePlugin } from "./mode-workflow-plugin.ts";
 
 // Import default instances
 import configPlugin from "./config-plugin.ts";
 import toolNameMappingPlugin from "./tool-name-mapping-plugin.ts";
 import loggingPlugin from "./logging-plugin.ts";
+import agenticModePlugin from "./mode-agentic-plugin.ts";
+import workflowModePlugin from "./mode-workflow-plugin.ts";
 
 /**
  * Get all built-in plugins in the correct order
@@ -19,6 +23,8 @@ export function getBuiltInPlugins() {
   return [
     toolNameMappingPlugin, // First: establish name mappings
     configPlugin, // Second: apply configurations
+    agenticModePlugin, // Third: agentic mode handler
+    workflowModePlugin, // Fourth: workflow mode handler
     loggingPlugin, // Last: logging
   ];
 }

--- a/packages/core/src/plugins/built-in/mode-agentic-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-agentic-plugin.ts
@@ -1,0 +1,30 @@
+/**
+ * Agentic Mode Plugin
+ * Implements the "agentic" execution mode as a built-in plugin
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerAgenticTool } from "../../executors/agentic/agentic-tool-registrar.ts";
+
+export const createAgenticModePlugin = (): ToolPlugin => ({
+  name: "mode-agentic",
+  version: "1.0.0",
+
+  // Only apply to agentic mode
+  apply: "agentic",
+
+  // Register the agent tool
+  registerAgentTool: (context) => {
+    registerAgenticTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+      sampling: context.options.sampling,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createAgenticModePlugin();

--- a/packages/core/src/plugins/built-in/mode-workflow-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-workflow-plugin.ts
@@ -1,0 +1,33 @@
+/**
+ * Workflow Mode Plugin
+ * Implements the "agentic_workflow" execution mode as a built-in plugin
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerAgenticWorkflowTool } from "../../executors/workflow/workflow-tool-registrar.ts";
+
+export const createWorkflowModePlugin = (): ToolPlugin => ({
+  name: "mode-workflow",
+  version: "1.0.0",
+
+  // Only apply to workflow mode
+  apply: "agentic_workflow",
+
+  // Register the agent tool
+  registerAgentTool: (context) => {
+    registerAgenticWorkflowTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+      predefinedSteps: context.options.steps,
+      sampling: context.options.sampling,
+      ensureStepActions: context.options.ensureStepActions,
+      toolNameToIdMapping: context.toolNameToIdMapping,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createWorkflowModePlugin();

--- a/packages/core/src/set-up-mcp-compose.ts
+++ b/packages/core/src/set-up-mcp-compose.ts
@@ -5,6 +5,7 @@ import type { MCPSetting } from "./service/tools.ts";
 import type { SamplingConfig } from "./types.ts";
 import type { ToolPlugin } from "./plugin-types.ts";
 import type { ToolRefXml } from "./types.ts";
+import type { ExecutionMode } from "./prompts/types.ts";
 
 export interface ComposeDefinition {
   /**
@@ -39,7 +40,7 @@ export interface ComposeDefinition {
      * - "agentic_workflow": Agent workflow mode that can either generate steps at runtime or use predefined steps
      * @default "agentic"
      */
-    mode?: "agentic" | "agentic_workflow";
+    mode?: ExecutionMode;
 
     /**
      * Enable MCP sampling-based autonomous execution capability

--- a/packages/core/src/utils/plugin-manager.ts
+++ b/packages/core/src/utils/plugin-manager.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  AgentToolRegistrationContext,
   ComposedTool,
   ComposeEndContext,
   ComposeStartContext,
@@ -232,6 +233,44 @@ export class PluginManager {
         }
       }
     }
+  }
+
+  /**
+   * Trigger registerAgentTool hook - allows plugins to register the main agent tool
+   * Returns true if any plugin handled the registration
+   */
+  async triggerRegisterAgentTool(
+    context: AgentToolRegistrationContext,
+  ): Promise<boolean> {
+    const registerPlugins = this.plugins.filter(
+      (p) => p.registerAgentTool && shouldApplyPlugin(p, context.mode),
+    );
+
+    if (registerPlugins.length === 0) {
+      return false;
+    }
+
+    // Sort plugins - last one wins (reverse order)
+    const sortedPlugins = sortPluginsByOrder(registerPlugins).reverse();
+
+    for (const plugin of sortedPlugins) {
+      if (plugin.registerAgentTool) {
+        try {
+          await plugin.registerAgentTool(context);
+          // First successful registration wins
+          return true;
+        } catch (error) {
+          const errorMsg = error instanceof Error
+            ? error.message
+            : String(error);
+          await this.logger.error(
+            `Plugin "${plugin.name}" registerAgentTool failed: ${errorMsg}`,
+          );
+        }
+      }
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a major refactor to the execution mode system for the MCP compose server, moving from hardcoded handling of agentic and workflow modes to a flexible plugin-based architecture. Execution modes are now implemented as plugins, allowing for easier extensibility and customization. The changes include new plugin hooks, type updates, and the registration of built-in mode plugins.

**Plugin System Refactor (most important):**
* Added a new `registerAgentTool` hook to the `ToolPlugin` interface, enabling plugins to register custom agent tool implementations for different execution modes.
* Refactored the server to trigger the `registerAgentTool` plugin hook instead of directly registering agentic or workflow tools; throws an error if no plugin handles the mode.
* Implemented built-in plugins for `"agentic"` and `"agentic_workflow"` modes, replacing previous direct registration logic. (`mode-agentic-plugin.ts`, `mode-workflow-plugin.ts`) [[1]](diffhunk://#diff-b14d453f613006ba58d63711f1c608d1fa510b37aaf7d52e4b03a312c3a7673dR1-R30) [[2]](diffhunk://#diff-ce5b40023a2894ce78fb9e4595ffcc4a2b48a8e5bbed00fdbd02a84815b5aaa0R1-R33) [[3]](diffhunk://#diff-8fc9159f47f973ed67640078baf6d780321d564cd3e17048b563c4b96243002fR9-R17) [[4]](diffhunk://#diff-8fc9159f47f973ed67640078baf6d780321d564cd3e17048b563c4b96243002fR26-R27)

**Type System Improvements:**
* Updated all relevant types and interfaces to use the new `ExecutionMode` type instead of string literals for mode selection. [[1]](diffhunk://#diff-e554a40116af2766f57d71c230ac9df8c604215718b887a40f3b8a067449ff41L27-R28) [[2]](diffhunk://#diff-e554a40116af2766f57d71c230ac9df8c604215718b887a40f3b8a067449ff41L87-R97) [[3]](diffhunk://#diff-e554a40116af2766f57d71c230ac9df8c604215718b887a40f3b8a067449ff41L97-R107) [[4]](diffhunk://#diff-e554a40116af2766f57d71c230ac9df8c604215718b887a40f3b8a067449ff41L107-R148) [[5]](diffhunk://#diff-c66a2187e15de3aa9c0af38816ec08a84e3bd0d2bab10496a1d0f9c9310c6d3eR8) [[6]](diffhunk://#diff-c66a2187e15de3aa9c0af38816ec08a84e3bd0d2bab10496a1d0f9c9310c6d3eL42-R43) [[7]](diffhunk://#diff-a886bf967f4c82a07ba68299d6a8a3dd6ddf46bf19bfb30a2d43c686524eeaf2L346-R345) [[8]](diffhunk://#diff-e554a40116af2766f57d71c230ac9df8c604215718b887a40f3b8a067449ff41R9)

**Plugin Utility and Manager Enhancements:**
* Modified plugin application logic to match modes exactly and added support for the new hook in plugin validation. [[1]](diffhunk://#diff-de8717865bc8f995628d1462fccd72ebe16fb55c35d432c25c31a82069e82b12L18-R23) [[2]](diffhunk://#diff-de8717865bc8f995628d1462fccd72ebe16fb55c35d432c25c31a82069e82b12R115)
* Added `triggerRegisterAgentTool` method to the `PluginManager` for handling agent tool registration via plugins.

**Exports and Imports:**
* Updated module exports to include new plugin types and built-in plugins in `mod.ts` and `built-in/index.ts`. [[1]](diffhunk://#diff-8d219ee2baa3f4f76c8df9f18ffe503e6fae769231f5a3d5c83232ad356f215aR53-R64) [[2]](diffhunk://#diff-8fc9159f47f973ed67640078baf6d780321d564cd3e17048b563c4b96243002fR9-R17)

**Minor Fixes and Improvements:**
* Passed `toolName` to planning prompts in `AgenticExecutor` to improve context. [[1]](diffhunk://#diff-a807fcdb2543eecb47f29e6c1467c67b15552aad16fb65e0655f76288f0113f9R157) [[2]](diffhunk://#diff-a807fcdb2543eecb47f29e6c1467c67b15552aad16fb65e0655f76288f0113f9R213)