### PR TITLE
refactor: convert sampling from option to independent mode plugins

### DIFF
--- a/packages/core/examples/sampling/01-basic-composition.ts
+++ b/packages/core/examples/sampling/01-basic-composition.ts
@@ -18,8 +18,7 @@ export const toolDefinitions: ComposeDefinition[] = [
   {
     name: "file-organizer",
     options: {
-      sampling: true,
-      mode: "agentic_workflow",
+      mode: "agentic_sampling",
     },
     description:
       `I am a smart file organizer that helps users manage their files efficiently.

--- a/packages/core/src/executors/agentic/agentic-sampling-registrar.ts
+++ b/packages/core/src/executors/agentic/agentic-sampling-registrar.ts
@@ -1,0 +1,74 @@
+import { jsonSchema } from "../../utils/schema.ts";
+import type { SamplingConfig } from "../../types.ts";
+import { createGoogleCompatibleJSONSchema } from "../../utils/common/provider.ts";
+import type { ComposableMCPServer } from "../../compose.ts";
+import { CompiledPrompts } from "../../prompts/index.ts";
+import { SamplingExecutor } from "../sampling/agentic-sampling-executor.ts";
+import type { ExternalTool } from "../sampling/base-sampling-executor.ts";
+import { createArgsDefFactory } from "../../factories/args-def-factory.ts";
+
+export interface RegisterAgenticSamplingToolParams {
+  description: string;
+  name: string;
+  allToolNames: string[];
+  depGroups: Record<string, unknown>;
+  toolNameToDetailList: [string, unknown][];
+  samplingConfig?: SamplingConfig;
+}
+
+export function registerAgenticSamplingTool(
+  server: ComposableMCPServer,
+  {
+    description,
+    name,
+    allToolNames,
+    depGroups,
+    toolNameToDetailList,
+    samplingConfig,
+  }: RegisterAgenticSamplingToolParams,
+) {
+  const createArgsDef = createArgsDefFactory(
+    name,
+    allToolNames,
+    depGroups,
+    undefined,
+    undefined,
+  );
+
+  // Create sampling executor
+  const samplingExecutor = new SamplingExecutor(
+    name,
+    description,
+    allToolNames,
+    toolNameToDetailList as [string, ExternalTool][],
+    server,
+    samplingConfig,
+  );
+
+  // Use sampling-specific prompt
+  description = CompiledPrompts.samplingExecution({
+    toolName: name,
+    description,
+    toolList: allToolNames.map((name) => `- ${name}`).join("\n"),
+  });
+
+  // Use sampling-specific args definition
+  const argsDef = createArgsDef.forSampling();
+  const schema = allToolNames.length > 0
+    ? argsDef
+    : { type: "object", properties: {} };
+
+  server.tool(
+    name,
+    description,
+    jsonSchema<Record<string, unknown>>(
+      createGoogleCompatibleJSONSchema(schema as Record<string, unknown>),
+    ),
+    async (args: Record<string, unknown>) => {
+      return await samplingExecutor.executeSampling(
+        args,
+        schema as Record<string, unknown>,
+      );
+    },
+  );
+}

--- a/packages/core/src/executors/agentic/agentic-tool-registrar.ts
+++ b/packages/core/src/executors/agentic/agentic-tool-registrar.ts
@@ -4,8 +4,6 @@ import { createGoogleCompatibleJSONSchema } from "../../utils/common/provider.ts
 import type { ComposableMCPServer } from "../../compose.ts";
 import { CompiledPrompts } from "../../prompts/index.ts";
 import { AgenticExecutor } from "./agentic-executor.ts";
-import { SamplingExecutor } from "../sampling/agentic-sampling-executor.ts";
-import type { ExternalTool } from "../sampling/base-sampling-executor.ts";
 import { createArgsDefFactory } from "../../factories/args-def-factory.ts";
 
 export function registerAgenticTool(
@@ -16,7 +14,6 @@ export function registerAgenticTool(
     allToolNames,
     depGroups,
     toolNameToDetailList,
-    sampling = false,
   }: RegisterToolParams,
 ) {
   const createArgsDef = createArgsDefFactory(
@@ -27,11 +24,7 @@ export function registerAgenticTool(
     undefined,
   );
 
-  // Determine if sampling mode is enabled and extract config
-  const isSamplingMode = sampling === true || typeof sampling === "object";
-  const samplingConfig = typeof sampling === "object" ? sampling : undefined;
-
-  // Create executors
+  // Create executor
   const agenticExecutor = new AgenticExecutor(
     name,
     allToolNames,
@@ -39,32 +32,17 @@ export function registerAgenticTool(
     server,
   );
 
-  const samplingExecutor = new SamplingExecutor(
-    name,
+  description = CompiledPrompts.autonomousExecution({
+    toolName: name,
     description,
-    allToolNames,
-    toolNameToDetailList as [string, ExternalTool][],
-    server,
-    samplingConfig,
-  );
-
-  description = isSamplingMode
-    ? CompiledPrompts.samplingExecution({
-      toolName: name,
-      description,
-      toolList: allToolNames.map((name) => `- ${name}`).join("\n"),
-    })
-    : CompiledPrompts.autonomousExecution({
-      toolName: name,
-      description,
-    });
+  });
 
   const agenticArgsDef = createArgsDef.forAgentic(
     toolNameToDetailList,
     false, // not sampling mode
   );
   const argsDef: Schema<Record<PropertyKey, never>>["jsonSchema"] =
-    isSamplingMode ? createArgsDef.forSampling() : agenticArgsDef;
+    agenticArgsDef;
   const schema = allToolNames.length > 0
     ? argsDef
     : { type: "object", properties: {} };
@@ -76,18 +54,10 @@ export function registerAgenticTool(
       createGoogleCompatibleJSONSchema(schema as Record<string, unknown>),
     ),
     async (args: Record<string, unknown>) => {
-      // Use appropriate executor based on mode
-      if (isSamplingMode) {
-        return await samplingExecutor.executeSampling(
-          args,
-          schema as Record<string, unknown>,
-        );
-      } else {
-        return await agenticExecutor.execute(
-          args,
-          schema as Record<string, unknown>,
-        );
-      }
+      return await agenticExecutor.execute(
+        args,
+        schema as Record<string, unknown>,
+      );
     },
   );
 }

--- a/packages/core/src/executors/workflow/workflow-sampling-registrar.ts
+++ b/packages/core/src/executors/workflow/workflow-sampling-registrar.ts
@@ -1,0 +1,101 @@
+import { jsonSchema } from "../../utils/schema.ts";
+import type { SamplingConfig } from "../../types.ts";
+import type { MCPCStep } from "../../utils/state.ts";
+import { WorkflowState } from "../../utils/state.ts";
+import { createGoogleCompatibleJSONSchema } from "../../utils/common/provider.ts";
+import type { ComposableMCPServer } from "../../compose.ts";
+import { CompiledPrompts } from "../../prompts/index.ts";
+import { createArgsDefFactory } from "../../factories/args-def-factory.ts";
+import { WorkflowSamplingExecutor } from "../sampling/workflow-sampling-executor.ts";
+import type { ExternalTool } from "../sampling/base-sampling-executor.ts";
+
+export interface RegisterWorkflowSamplingToolParams {
+  description: string;
+  name: string;
+  allToolNames: string[];
+  depGroups: Record<string, unknown>;
+  toolNameToDetailList: [string, unknown][];
+  predefinedSteps?: MCPCStep[];
+  samplingConfig?: SamplingConfig;
+  ensureStepActions?: string[];
+  toolNameToIdMapping?: Map<string, string>;
+}
+
+export function registerWorkflowSamplingTool(
+  server: ComposableMCPServer,
+  {
+    description,
+    name,
+    allToolNames,
+    depGroups,
+    toolNameToDetailList,
+    predefinedSteps,
+    samplingConfig,
+    ensureStepActions,
+    toolNameToIdMapping: _toolNameToIdMapping,
+  }: RegisterWorkflowSamplingToolParams,
+) {
+  const createArgsDef = createArgsDefFactory(
+    name,
+    allToolNames,
+    depGroups,
+    predefinedSteps,
+    ensureStepActions,
+  );
+
+  // Create sampling executor
+  const workflowSamplingExecutor = new WorkflowSamplingExecutor(
+    name,
+    description,
+    allToolNames,
+    toolNameToDetailList as [string, ExternalTool][],
+    createArgsDef,
+    server,
+    predefinedSteps,
+    samplingConfig,
+  );
+
+  const workflowState = new WorkflowState();
+
+  // Use sampling-specific prompt
+  const baseDescription = CompiledPrompts.samplingExecution({
+    toolName: name,
+    description,
+    toolList: allToolNames.map((name) => `- ${name}`).join("\n"),
+  });
+
+  // Use sampling-specific args definition
+  const argsDef = createArgsDef.forSampling();
+
+  const schema = allToolNames.length > 0
+    ? argsDef
+    : { type: "object", properties: {} };
+
+  server.tool(
+    name,
+    baseDescription,
+    jsonSchema<Record<string, unknown>>(
+      createGoogleCompatibleJSONSchema(schema as Record<string, unknown>),
+    ),
+    async (args: Record<string, unknown>) => {
+      try {
+        return await workflowSamplingExecutor.executeWorkflowSampling(
+          args,
+          schema as Record<string, unknown>,
+          workflowState,
+        );
+      } catch (error) {
+        workflowState.reset();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Workflow execution error: ${(error as Error).message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/core/src/executors/workflow/workflow-tool-registrar.ts
+++ b/packages/core/src/executors/workflow/workflow-tool-registrar.ts
@@ -6,8 +6,6 @@ import { WorkflowExecutor } from "./workflow-executor.ts";
 import type { ComposableMCPServer } from "../../compose.ts";
 import { CompiledPrompts } from "../../prompts/index.ts";
 import { createArgsDefFactory } from "../../factories/args-def-factory.ts";
-import { WorkflowSamplingExecutor } from "../sampling/workflow-sampling-executor.ts";
-import type { ExternalTool } from "../sampling/base-sampling-executor.ts";
 
 export function registerAgenticWorkflowTool(
   server: ComposableMCPServer,
@@ -18,7 +16,6 @@ export function registerAgenticWorkflowTool(
     depGroups,
     toolNameToDetailList,
     predefinedSteps,
-    sampling = false,
     ensureStepActions,
     toolNameToIdMapping,
   }: RegisterWorkflowToolParams,
@@ -31,11 +28,7 @@ export function registerAgenticWorkflowTool(
     ensureStepActions,
   );
 
-  // Determine if sampling mode is enabled and extract config
-  const isSamplingMode = sampling === true || typeof sampling === "object";
-  const samplingConfig = typeof sampling === "object" ? sampling : undefined;
-
-  // Create executors
+  // Create executor
   const workflowExecutor = new WorkflowExecutor(
     name,
     allToolNames,
@@ -47,44 +40,26 @@ export function registerAgenticWorkflowTool(
     toolNameToIdMapping,
   );
 
-  const workflowSamplingExecutor = new WorkflowSamplingExecutor(
-    name,
-    description,
-    allToolNames,
-    toolNameToDetailList as [string, ExternalTool][],
-    createArgsDef,
-    server,
-    predefinedSteps,
-    samplingConfig,
-  );
-
   const workflowState = new WorkflowState();
 
   const planningInstructions = predefinedSteps
     ? "- Set `init: true` (steps are predefined)"
     : "- Set `init: true` and define complete `steps` array";
 
-  // Generate description based on mode
-  const baseDescription = isSamplingMode
-    ? CompiledPrompts.samplingExecution({
-      toolName: name,
-      description,
-      toolList: allToolNames.map((name) => `- ${name}`).join("\n"),
-    })
-    : CompiledPrompts.workflowExecution({
-      toolName: name,
-      description: description,
-      planningInstructions,
-    });
+  // Generate description
+  const baseDescription = CompiledPrompts.workflowExecution({
+    toolName: name,
+    description: description,
+    planningInstructions,
+  });
 
-  // Generate schema based on mode
-  const argsDef = isSamplingMode
-    ? createArgsDef.forSampling()
-    : createArgsDef.forTool();
+  // Generate schema
+  const argsDef = createArgsDef.forTool();
 
-  const toolDescription = isSamplingMode
-    ? baseDescription
-    : createArgsDef.forToolDescription(baseDescription, workflowState);
+  const toolDescription = createArgsDef.forToolDescription(
+    baseDescription,
+    workflowState,
+  );
 
   server.tool(
     name,
@@ -94,16 +69,7 @@ export function registerAgenticWorkflowTool(
     ),
     async (args: Record<string, unknown>) => {
       try {
-        // Use appropriate executor based on mode
-        if (isSamplingMode) {
-          return await workflowSamplingExecutor.executeWorkflowSampling(
-            args as Record<string, unknown>,
-            argsDef as Record<string, unknown>,
-            workflowState,
-          );
-        } else {
-          return await workflowExecutor.execute(args, workflowState);
-        }
+        return await workflowExecutor.execute(args, workflowState);
       } catch (error) {
         workflowState.reset();
         return {

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -134,7 +134,7 @@ export interface AgentToolRegistrationContext {
   hiddenToolNames: string[];
   options: {
     mode?: string;
-    sampling?: boolean | { maxIterations?: number; summarize?: boolean };
+    samplingConfig?: { maxIterations?: number; summarize?: boolean };
     steps?: Array<{ description: string; actions: string[] }>;
     ensureStepActions?: string[];
     [key: string]: unknown;

--- a/packages/core/src/plugins/built-in/index.ts
+++ b/packages/core/src/plugins/built-in/index.ts
@@ -8,6 +8,8 @@ export { createToolNameMappingPlugin } from "./tool-name-mapping-plugin.ts";
 export { createLoggingPlugin } from "./logging-plugin.ts";
 export { createAgenticModePlugin } from "./mode-agentic-plugin.ts";
 export { createWorkflowModePlugin } from "./mode-workflow-plugin.ts";
+export { createAgenticSamplingModePlugin } from "./mode-agentic-sampling-plugin.ts";
+export { createWorkflowSamplingModePlugin } from "./mode-workflow-sampling-plugin.ts";
 
 // Import default instances
 import configPlugin from "./config-plugin.ts";
@@ -15,6 +17,8 @@ import toolNameMappingPlugin from "./tool-name-mapping-plugin.ts";
 import loggingPlugin from "./logging-plugin.ts";
 import agenticModePlugin from "./mode-agentic-plugin.ts";
 import workflowModePlugin from "./mode-workflow-plugin.ts";
+import agenticSamplingModePlugin from "./mode-agentic-sampling-plugin.ts";
+import workflowSamplingModePlugin from "./mode-workflow-sampling-plugin.ts";
 
 /**
  * Get all built-in plugins in the correct order
@@ -25,6 +29,8 @@ export function getBuiltInPlugins() {
     configPlugin, // Second: apply configurations
     agenticModePlugin, // Third: agentic mode handler
     workflowModePlugin, // Fourth: workflow mode handler
+    agenticSamplingModePlugin, // Fifth: agentic sampling mode handler
+    workflowSamplingModePlugin, // Sixth: workflow sampling mode handler
     loggingPlugin, // Last: logging
   ];
 }

--- a/packages/core/src/plugins/built-in/mode-agentic-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-agentic-plugin.ts
@@ -21,7 +21,6 @@ export const createAgenticModePlugin = (): ToolPlugin => ({
       allToolNames: context.allToolNames,
       depGroups: context.depGroups,
       toolNameToDetailList: context.toolNameToDetailList,
-      sampling: context.options.sampling,
     });
   },
 });

--- a/packages/core/src/plugins/built-in/mode-agentic-sampling-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-agentic-sampling-plugin.ts
@@ -1,0 +1,31 @@
+/**
+ * Agentic Sampling Mode Plugin
+ * Implements the "agentic_sampling" execution mode as a built-in plugin
+ * This mode enables autonomous execution with sampling capabilities
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerAgenticSamplingTool } from "../../executors/agentic/agentic-sampling-registrar.ts";
+
+export const createAgenticSamplingModePlugin = (): ToolPlugin => ({
+  name: "mode-agentic-sampling",
+  version: "1.0.0",
+
+  // Only apply to agentic_sampling mode
+  apply: "agentic_sampling",
+
+  // Register the agent tool with sampling
+  registerAgentTool: (context) => {
+    registerAgenticSamplingTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+      samplingConfig: context.options.samplingConfig,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createAgenticSamplingModePlugin();

--- a/packages/core/src/plugins/built-in/mode-workflow-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-workflow-plugin.ts
@@ -22,7 +22,6 @@ export const createWorkflowModePlugin = (): ToolPlugin => ({
       depGroups: context.depGroups,
       toolNameToDetailList: context.toolNameToDetailList,
       predefinedSteps: context.options.steps,
-      sampling: context.options.sampling,
       ensureStepActions: context.options.ensureStepActions,
       toolNameToIdMapping: context.toolNameToIdMapping,
     });

--- a/packages/core/src/plugins/built-in/mode-workflow-sampling-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-workflow-sampling-plugin.ts
@@ -1,0 +1,34 @@
+/**
+ * Workflow Sampling Mode Plugin
+ * Implements the "agentic_workflow_sampling" execution mode as a built-in plugin
+ * This mode enables autonomous workflow execution with sampling capabilities
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerWorkflowSamplingTool } from "../../executors/workflow/workflow-sampling-registrar.ts";
+
+export const createWorkflowSamplingModePlugin = (): ToolPlugin => ({
+  name: "mode-agentic-workflow-sampling",
+  version: "1.0.0",
+
+  // Only apply to agentic_workflow_sampling mode
+  apply: "agentic_workflow_sampling",
+
+  // Register the agent tool with sampling
+  registerAgentTool: (context) => {
+    registerWorkflowSamplingTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+      predefinedSteps: context.options.steps,
+      samplingConfig: context.options.samplingConfig,
+      ensureStepActions: context.options.ensureStepActions,
+      toolNameToIdMapping: context.toolNameToIdMapping,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createWorkflowSamplingModePlugin();

--- a/packages/core/src/prompts/types.ts
+++ b/packages/core/src/prompts/types.ts
@@ -29,7 +29,11 @@ export interface WorkflowStep {
 /**
  * Execution mode types
  */
-export type ExecutionMode = "agentic" | "agentic_workflow";
+export type ExecutionMode =
+  | "agentic"
+  | "agentic_workflow"
+  | "agentic_sampling"
+  | "agentic_workflow_sampling";
 
 /**
  * Prompt template configuration

--- a/packages/core/src/set-up-mcp-compose.ts
+++ b/packages/core/src/set-up-mcp-compose.ts
@@ -38,16 +38,17 @@ export interface ComposeDefinition {
      * Execution mode for the agent
      * - "agentic": Fully autonomous agent mode without any workflow structure
      * - "agentic_workflow": Agent workflow mode that can either generate steps at runtime or use predefined steps
+     * - "agentic_sampling": Autonomous sampling mode for agentic execution
+     * - "agentic_workflow_sampling": Autonomous sampling mode for workflow execution
      * @default "agentic"
      */
     mode?: ExecutionMode;
 
     /**
-     * Enable MCP sampling-based autonomous execution capability
-     * When enabled, adds sampling tools that can execute tasks autonomously
-     * @default false
+     * Configuration for sampling mode execution
+     * Only applies when mode is "agentic_sampling" or "agentic_workflow_sampling"
      */
-    sampling?: boolean | SamplingConfig;
+    samplingConfig?: SamplingConfig;
 
     /**
      * Optional predefined workflow steps for agentic_workflow mode
@@ -147,7 +148,7 @@ export function parseMcpcConfigs(
  *       }
  *     },
  *     plugins: [createLargeResultPlugin({ maxSize: 8000 })],
- *     options: { mode: "agentic", sampling: true }
+ *     options: { mode: "agentic_sampling" }
  *   }]
  * );
  * await server.connect(new StdioServerTransport());

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,7 +17,6 @@ export interface RegisterToolParams {
   allToolNames: string[];
   depGroups: Record<string, unknown>;
   toolNameToDetailList: [string, unknown][];
-  sampling?: boolean | SamplingConfig;
 }
 
 export interface RegisterWorkflowToolParams extends RegisterToolParams {

--- a/packages/core/src/utils/compose-helpers.ts
+++ b/packages/core/src/utils/compose-helpers.ts
@@ -7,6 +7,7 @@ import type { ComposableMCPServer } from "../compose.ts";
 import type { ComposedTool } from "../plugin-types.ts";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema } from "../types.ts";
+import type { ExecutionMode } from "../prompts/types.ts";
 import { updateRefPaths } from "./common/schema.ts";
 import { jsonSchema } from "./schema.ts";
 import { sanitizePropertyKey } from "./common/provider.ts";
@@ -17,7 +18,7 @@ import { sanitizePropertyKey } from "./common/provider.ts";
 export async function processToolsWithPlugins(
   server: ComposableMCPServer,
   externalTools: Record<string, ComposedTool>,
-  mode: "agentic" | "agentic_workflow",
+  mode: ExecutionMode,
 ): Promise<void> {
   const toolManager = (server as any).toolManager;
   const pluginManager = (server as any).pluginManager;

--- a/packages/mcpc-builder/mcpc-builder-agent.ts
+++ b/packages/mcpc-builder/mcpc-builder-agent.ts
@@ -55,7 +55,7 @@ const server = await mcpc(
   [
     {
       name: "mcpc-builder-agent",
-      options: { mode: "agentic", sampling: false },
+      options: { mode: "agentic" },
       description,
       deps,
     },


### PR DESCRIPTION
- Add new execution modes: agentic_sampling and agentic_workflow_sampling
- Create dedicated mode plugins for sampling (mode-agentic-sampling-plugin.ts, mode-workflow-sampling-plugin.ts)
- Create separate registrar functions for sampling modes
- Remove sampling parameter from existing mode plugins and registrars
- Update ComposeDefinition to use samplingConfig instead of sampling option
- Simplify mode-specific logic by eliminating conditional sampling checks
- Update examples to use new mode naming convention

This refactor improves maintainability by:
- Separating concerns: each mode has its own plugin
- Eliminating confusing option/mode mixing
- Making execution modes explicit and type-safe
- Simplifying codebase by removing conditional branching