### PR TITLE
feat: add dynamic prompting and toolchange execution modes

### DIFF
--- a/packages/core/examples/14-dynamic-prompting-mode.ts
+++ b/packages/core/examples/14-dynamic-prompting-mode.ts
@@ -1,0 +1,69 @@
+/**
+ * MCPC Example: Dynamic Prompting Mode
+ *
+ * Demonstrates the dynamic_prompting execution mode which provides
+ * a two-stage interaction model:
+ * 1. First, user/LLM selects which action/tool to use
+ * 2. Then, agent prompts for specific parameters needed for that tool
+ *
+ * This helps reduce tool confusion and improves parameter gathering accuracy.
+ *
+ * Usage:
+ *   deno run --allow-all packages/core/examples/14-dynamic-prompting-mode.ts
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { mcpc } from "../mod.ts";
+
+const toolDefinitions = [
+  {
+    name: "file-manager",
+    description: `I am a file management agent that uses dynamic prompting.
+
+Instead of overwhelming you with all parameters at once, I'll:
+1. First ask you to select which file operation you want to perform
+2. Then guide you through providing the specific parameters for that operation
+
+**Available Operations:**
+<tool name="desktop-commander.read_file"/>
+<tool name="desktop-commander.write_file"/>
+<tool name="desktop-commander.list_directory"/>
+<tool name="desktop-commander.create_directory"/>
+<tool name="desktop-commander.move_file"/>
+
+This two-stage approach helps ensure you provide the right information for each operation.`,
+
+    deps: {
+      mcpServers: {
+        "desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+          transportType: "stdio" as const,
+        },
+      },
+    },
+    options: {
+      mode: "dynamic_prompting" as const,
+    },
+  },
+];
+
+export const server = await mcpc(
+  [
+    {
+      name: "dynamic-prompting-demo",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {
+          listChanged: true,
+        },
+      },
+    },
+  ],
+  toolDefinitions,
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/core/examples/15-dynamic-toolchange-mode.ts
+++ b/packages/core/examples/15-dynamic-toolchange-mode.ts
@@ -1,0 +1,87 @@
+/**
+ * MCPC Example: Dynamic Tool Change Mode
+ *
+ * Demonstrates the dynamic_toolchange execution mode which allows:
+ * - Runtime enabling/disabling of tools
+ * - Client notification when tool list changes
+ * - Reduced initial tool overload
+ *
+ * This is inspired by GitHub MCP Server's dynamic toolsets feature where
+ * you start with a small set of tools and dynamically enable more as needed.
+ *
+ * Usage:
+ *   deno run --allow-all packages/core/examples/15-dynamic-toolchange-mode.ts
+ *
+ * Example interactions:
+ *   1. "List the currently enabled tools"
+ *   2. "Enable the write_file and create_directory tools"
+ *   3. "Now write a file to /tmp/test.txt with content 'Hello World'"
+ *   4. "Disable the write_file tool"
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { mcpc } from "../mod.ts";
+
+const toolDefinitions = [
+  {
+    name: "adaptive-file-manager",
+    description:
+      `I am an adaptive file management agent that uses dynamic tool changes.
+
+I can help you manage which file operations are currently available:
+- Start with commonly used operations enabled
+- Enable additional operations only when needed
+- Disable operations you don't want to use
+
+**Tool Management:**
+- Use 'enable_tools' to activate specific tools
+- Use 'disable_tools' to deactivate specific tools
+- Tool changes trigger client notifications for better UX
+
+**Available Tools:**
+<tool name="desktop-commander.read_file"/>
+<tool name="desktop-commander.write_file"/>
+<tool name="desktop-commander.list_directory"/>
+<tool name="desktop-commander.create_directory"/>
+<tool name="desktop-commander.move_file"/>
+<tool name="desktop-commander.delete_file"/>
+
+This approach helps:
+1. Reduce initial tool confusion
+2. Improve performance by limiting active tools
+3. Provide better control over available operations`,
+
+    deps: {
+      mcpServers: {
+        "desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+          transportType: "stdio" as const,
+        },
+      },
+    },
+    options: {
+      mode: "dynamic_toolchange" as const,
+    },
+  },
+];
+
+export const server = await mcpc(
+  [
+    {
+      name: "dynamic-toolchange-demo",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {
+          listChanged: true, // Important: Enable tool list change notifications
+        },
+      },
+    },
+  ],
+  toolDefinitions,
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/core/src/executors/dynamic-prompting/dynamic-prompting-executor.ts
+++ b/packages/core/src/executors/dynamic-prompting/dynamic-prompting-executor.ts
@@ -1,0 +1,101 @@
+/**
+ * Dynamic Prompting Executor
+ *
+ * Implements a two-stage execution model:
+ * 1. User selects an action/tool they want to execute
+ * 2. Agent prompts user for specific parameters needed for that tool
+ *
+ * This helps reduce tool confusion by splitting tool selection from parameter gathering.
+ */
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ComposableMCPServer } from "../../compose.ts";
+
+export class DynamicPromptingExecutor {
+  constructor(
+    private readonly toolName: string,
+    private readonly availableToolNames: string[],
+    private readonly toolNameToDetails: Array<[string, any]>,
+    private readonly server: ComposableMCPServer,
+  ) {}
+
+  async execute(
+    args: Record<string, unknown>,
+    _schema: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const { action, parameters } = args;
+
+    // Stage 1: Action selection
+    if (!action) {
+      return {
+        content: [{
+          type: "text",
+          text: `Please select an action from the available tools:\n${
+            this.availableToolNames.map((name) => `- ${name}`).join("\n")
+          }\n\nProvide the action name in the 'action' parameter.`,
+        }],
+      };
+    }
+
+    // Stage 2: Parameter gathering
+    const actionStr = String(action);
+
+    // Check if tool exists
+    const toolDetail = this.toolNameToDetails.find(([name]) =>
+      name === actionStr
+    );
+    if (!toolDetail) {
+      return {
+        content: [{
+          type: "text",
+          text: `Action "${actionStr}" not found. Available actions:\n${
+            this.availableToolNames.map((name) => `- ${name}`).join("\n")
+          }`,
+        }],
+        isError: true,
+      };
+    }
+
+    // If parameters are not provided, prompt for them
+    if (!parameters || typeof parameters !== "object") {
+      const [toolName, toolDetails] = toolDetail;
+      const inputSchema = toolDetails.inputSchema || {};
+      const properties = inputSchema.properties || {};
+      const required = inputSchema.required || [];
+
+      const paramDescriptions = Object.entries(properties).map(
+        ([propName, propDef]: [string, any]) => {
+          const requiredMarker = required.includes(propName)
+            ? " (required)"
+            : " (optional)";
+          const description = propDef.description || "No description";
+          return `- ${propName}${requiredMarker}: ${description}`;
+        },
+      ).join("\n");
+
+      return {
+        content: [{
+          type: "text",
+          text:
+            `You selected action: ${toolName}\n\nPlease provide the following parameters:\n${paramDescriptions}\n\nProvide them in the 'parameters' field as a JSON object.`,
+        }],
+      };
+    }
+
+    // Stage 3: Execute the tool with parameters
+    try {
+      const result = await this.server.callTool(actionStr, parameters);
+      return result as CallToolResult;
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error executing ${actionStr}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        }],
+        isError: true,
+      };
+    }
+  }
+}

--- a/packages/core/src/executors/dynamic-prompting/dynamic-prompting-tool-registrar.ts
+++ b/packages/core/src/executors/dynamic-prompting/dynamic-prompting-tool-registrar.ts
@@ -1,0 +1,77 @@
+/**
+ * Dynamic Prompting Tool Registrar
+ *
+ * Registers an agent tool that uses the dynamic prompting execution model:
+ * 1. First, user/LLM selects which action/tool to use
+ * 2. Then, agent prompts for specific parameters needed for that tool
+ */
+
+import { jsonSchema, type Schema } from "../../utils/schema.ts";
+import type { RegisterToolParams } from "../../types.ts";
+import { createGoogleCompatibleJSONSchema } from "../../utils/common/provider.ts";
+import type { ComposableMCPServer } from "../../compose.ts";
+import { CompiledPrompts } from "../../prompts/index.ts";
+import { DynamicPromptingExecutor } from "./dynamic-prompting-executor.ts";
+
+export function registerDynamicPromptingTool(
+  server: ComposableMCPServer,
+  {
+    description,
+    name,
+    allToolNames,
+    toolNameToDetailList,
+  }: RegisterToolParams,
+) {
+  // Create executor
+  const executor = new DynamicPromptingExecutor(
+    name,
+    allToolNames,
+    toolNameToDetailList,
+    server,
+  );
+
+  // Enhance description with dynamic prompting instructions
+  description = CompiledPrompts.autonomousExecution({
+    toolName: name,
+    description:
+      `${description}\n\n**Dynamic Prompting Mode - IMPORTANT**\nThis agent REQUIRES a two-stage interaction:\n1. **FIRST**: You MUST call this tool with an 'action' parameter to select which tool to use\n2. **SECOND**: After seeing the action's schema, call again with both 'action' and 'parameters'\n\n⚠️ DO NOT guess parameters without first selecting an action!\n⚠️ The 'action' field is REQUIRED - you cannot proceed without it.`,
+  });
+
+  // Create schema for the two-stage model
+  const argsDef: Schema<Record<PropertyKey, never>>["jsonSchema"] = {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: allToolNames,
+        description:
+          "REQUIRED: The action/tool to execute. You MUST select an action first. Do NOT guess parameters without selecting an action.",
+      },
+      parameters: {
+        type: "object",
+        description:
+          "The parameters for the selected action. Provide after action selection.",
+        additionalProperties: true,
+      },
+    },
+    required: ["action"],
+  };
+
+  const schema = allToolNames.length > 0
+    ? argsDef
+    : { type: "object", properties: {} };
+
+  server.tool(
+    name,
+    description,
+    jsonSchema<Record<string, unknown>>(
+      createGoogleCompatibleJSONSchema(schema as Record<string, unknown>),
+    ),
+    async (args: Record<string, unknown>) => {
+      return await executor.execute(
+        args,
+        schema as Record<string, unknown>,
+      );
+    },
+  );
+}

--- a/packages/core/src/executors/dynamic-toolchange/dynamic-toolchange-executor.ts
+++ b/packages/core/src/executors/dynamic-toolchange/dynamic-toolchange-executor.ts
@@ -1,0 +1,136 @@
+/**
+ * Dynamic Tool Change Executor
+ *
+ * Implements dynamic tool parameter changes by:
+ * 1. Allowing tools to be modified at runtime
+ * 2. Notifying clients when tool definitions change
+ * 3. Maintaining state of which tools are currently available
+ *
+ * This is inspired by GitHub MCP Server's dynamic toolsets feature.
+ */
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ComposableMCPServer } from "../../compose.ts";
+
+export class DynamicToolChangeExecutor {
+  private enabledTools: Set<string>;
+
+  constructor(
+    private readonly toolName: string,
+    private readonly availableToolNames: string[],
+    private readonly toolNameToDetails: Array<[string, any]>,
+    private readonly server: ComposableMCPServer,
+  ) {
+    // Start with all tools enabled by default
+    this.enabledTools = new Set(availableToolNames);
+  }
+
+  /**
+   * Get list of currently enabled tools
+   */
+  getEnabledTools(): string[] {
+    return Array.from(this.enabledTools);
+  }
+
+  /**
+   * Enable specific tools and notify clients
+   */
+  async enableTools(toolNames: string[]): Promise<void> {
+    const newlyEnabled: string[] = [];
+
+    for (const toolName of toolNames) {
+      if (
+        this.availableToolNames.includes(toolName) &&
+        !this.enabledTools.has(toolName)
+      ) {
+        this.enabledTools.add(toolName);
+        newlyEnabled.push(toolName);
+      }
+    }
+
+    if (newlyEnabled.length > 0) {
+      // Notify clients that tool list has changed
+      await this.server.sendToolListChanged();
+    }
+  }
+
+  async execute(
+    args: Record<string, unknown>,
+    _schema: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const { action, parameters, enable_tools } = args;
+
+    // Handle tool enabling
+    if (enable_tools && Array.isArray(enable_tools)) {
+      await this.enableTools(enable_tools.map(String));
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Enabled tools: ${
+              enable_tools.join(
+                ", ",
+              )
+            }\nCurrently enabled: ${this.getEnabledTools().join(", ")}`,
+          },
+        ],
+      };
+    }
+
+    // Regular tool execution
+    if (!action) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Available actions:\n${
+              this.getEnabledTools()
+                .map((name) => `- ${name}`)
+                .join(
+                  "\n",
+                )
+            }\n\nSelect an action or use 'enable_tools' / 'disable_tools' to manage available tools.`,
+          },
+        ],
+      };
+    }
+
+    const actionStr = String(action);
+
+    // Check if tool is enabled
+    if (!this.enabledTools.has(actionStr)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Tool "${actionStr}" is not currently enabled. Use 'enable_tools' to enable it first.\nCurrently enabled: ${
+                this.getEnabledTools().join(
+                  ", ",
+                )
+              }`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // Execute the tool
+    try {
+      const result = await this.server.callTool(actionStr, parameters || {});
+      return result as CallToolResult;
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error executing ${actionStr}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+}

--- a/packages/core/src/executors/dynamic-toolchange/dynamic-toolchange-tool-registrar.ts
+++ b/packages/core/src/executors/dynamic-toolchange/dynamic-toolchange-tool-registrar.ts
@@ -1,0 +1,81 @@
+/**
+ * Dynamic Tool Change Tool Registrar
+ *
+ * Registers an agent tool that can dynamically enable/disable tools
+ * and notify clients when the tool list changes.
+ */
+
+import { jsonSchema, type Schema } from "../../utils/schema.ts";
+import type { RegisterToolParams } from "../../types.ts";
+import { createGoogleCompatibleJSONSchema } from "../../utils/common/provider.ts";
+import type { ComposableMCPServer } from "../../compose.ts";
+import { CompiledPrompts } from "../../prompts/index.ts";
+import { DynamicToolChangeExecutor } from "./dynamic-toolchange-executor.ts";
+
+export function registerDynamicToolChangeTool(
+  server: ComposableMCPServer,
+  {
+    description,
+    name,
+    allToolNames,
+    toolNameToDetailList,
+  }: RegisterToolParams,
+) {
+  // Create executor
+  const executor = new DynamicToolChangeExecutor(
+    name,
+    allToolNames,
+    toolNameToDetailList,
+    server,
+  );
+
+  // Enhance description with dynamic tool change instructions
+  description = CompiledPrompts.autonomousExecution({
+    toolName: name,
+    description:
+      `${description}\n\n**Dynamic Tool Change Mode - IMPORTANT**\nThis agent can dynamically enable tools as needed:\n- The 'action' field is REQUIRED - you MUST select a tool first\n- Use 'enable_tools' array to activate additional tools when you need more capabilities\n- Enabling tools triggers client notifications and makes them available immediately\n\n⚠️ DO NOT guess parameters! Always select an 'action' first.\n\nThis helps manage tool overload and improves performance by loading tools on demand.`,
+  });
+
+  // Create schema supporting both tool execution and management
+  const argsDef: Schema<Record<PropertyKey, never>>["jsonSchema"] = {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: allToolNames,
+        description:
+          "REQUIRED: The action/tool to execute from currently enabled tools. You MUST select an action first.",
+      },
+      parameters: {
+        type: "object",
+        description: "The parameters for the selected action.",
+        additionalProperties: true,
+      },
+      enable_tools: {
+        type: "array",
+        items: { type: "string", enum: allToolNames },
+        description:
+          "Optional: Array of tool names to enable for future use. Enabled tools will be available in subsequent calls.",
+      },
+    },
+    required: ["action"],
+  };
+
+  const schema = allToolNames.length > 0
+    ? argsDef
+    : { type: "object", properties: {} };
+
+  server.tool(
+    name,
+    description,
+    jsonSchema<Record<string, unknown>>(
+      createGoogleCompatibleJSONSchema(schema as Record<string, unknown>),
+    ),
+    async (args: Record<string, unknown>) => {
+      return await executor.execute(
+        args,
+        schema as Record<string, unknown>,
+      );
+    },
+  );
+}

--- a/packages/core/src/plugins/built-in/index.ts
+++ b/packages/core/src/plugins/built-in/index.ts
@@ -10,6 +10,8 @@ export { createAgenticModePlugin } from "./mode-agentic-plugin.ts";
 export { createWorkflowModePlugin } from "./mode-workflow-plugin.ts";
 export { createAgenticSamplingModePlugin } from "./mode-agentic-sampling-plugin.ts";
 export { createWorkflowSamplingModePlugin } from "./mode-workflow-sampling-plugin.ts";
+export { createDynamicPromptingModePlugin } from "./mode-dynamic-prompting-plugin.ts";
+export { createDynamicToolChangeModePlugin } from "./mode-dynamic-toolchange-plugin.ts";
 
 // Import default instances
 import configPlugin from "./config-plugin.ts";
@@ -19,6 +21,8 @@ import agenticModePlugin from "./mode-agentic-plugin.ts";
 import workflowModePlugin from "./mode-workflow-plugin.ts";
 import agenticSamplingModePlugin from "./mode-agentic-sampling-plugin.ts";
 import workflowSamplingModePlugin from "./mode-workflow-sampling-plugin.ts";
+import dynamicPromptingModePlugin from "./mode-dynamic-prompting-plugin.ts";
+import dynamicToolChangeModePlugin from "./mode-dynamic-toolchange-plugin.ts";
 
 /**
  * Get all built-in plugins in the correct order
@@ -31,6 +35,8 @@ export function getBuiltInPlugins() {
     workflowModePlugin, // Fourth: workflow mode handler
     agenticSamplingModePlugin, // Fifth: agentic sampling mode handler
     workflowSamplingModePlugin, // Sixth: workflow sampling mode handler
+    dynamicPromptingModePlugin, // Seventh: dynamic prompting mode handler
+    dynamicToolChangeModePlugin, // Eighth: dynamic tool change mode handler
     loggingPlugin, // Last: logging
   ];
 }

--- a/packages/core/src/plugins/built-in/mode-dynamic-prompting-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-dynamic-prompting-plugin.ts
@@ -1,0 +1,35 @@
+/**
+ * Dynamic Prompting Mode Plugin
+ * Implements the "dynamic_prompting" execution mode as a built-in plugin
+ *
+ * This mode provides a two-stage interaction:
+ * 1. Select action/tool
+ * 2. Provide parameters for that tool
+ *
+ * Similar to workflow mode but focused on interactive parameter gathering.
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerDynamicPromptingTool } from "../../executors/dynamic-prompting/dynamic-prompting-tool-registrar.ts";
+
+export const createDynamicPromptingModePlugin = (): ToolPlugin => ({
+  name: "mode-dynamic-prompting",
+  version: "1.0.0",
+
+  // Only apply to dynamic_prompting mode
+  apply: "dynamic_prompting",
+
+  // Register the agent tool
+  registerAgentTool: (context) => {
+    registerDynamicPromptingTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createDynamicPromptingModePlugin();

--- a/packages/core/src/plugins/built-in/mode-dynamic-toolchange-plugin.ts
+++ b/packages/core/src/plugins/built-in/mode-dynamic-toolchange-plugin.ts
@@ -1,0 +1,36 @@
+/**
+ * Dynamic Tool Change Mode Plugin
+ * Implements the "dynamic_toolchange" execution mode as a built-in plugin
+ *
+ * This mode allows:
+ * - Runtime enabling/disabling of tools
+ * - Client notification when tool list changes
+ * - Reduced initial tool overload
+ *
+ * Inspired by GitHub MCP Server's dynamic toolsets feature.
+ */
+
+import type { ToolPlugin } from "../../plugin-types.ts";
+import { registerDynamicToolChangeTool } from "../../executors/dynamic-toolchange/dynamic-toolchange-tool-registrar.ts";
+
+export const createDynamicToolChangeModePlugin = (): ToolPlugin => ({
+  name: "mode-dynamic-toolchange",
+  version: "1.0.0",
+
+  // Only apply to dynamic_toolchange mode
+  apply: "dynamic_toolchange",
+
+  // Register the agent tool
+  registerAgentTool: (context) => {
+    registerDynamicToolChangeTool(context.server, {
+      description: context.description,
+      name: context.name,
+      allToolNames: context.allToolNames,
+      depGroups: context.depGroups,
+      toolNameToDetailList: context.toolNameToDetailList,
+    });
+  },
+});
+
+// Export default instance for auto-loading
+export default createDynamicToolChangeModePlugin();

--- a/packages/core/src/prompts/types.ts
+++ b/packages/core/src/prompts/types.ts
@@ -33,7 +33,10 @@ export type ExecutionMode =
   | "agentic"
   | "agentic_workflow"
   | "agentic_sampling"
-  | "agentic_workflow_sampling";
+  | "agentic_workflow_sampling"
+  | "dynamic_prompting"
+  | "dynamic_toolchange"
+  | "custom";
 
 /**
  * Prompt template configuration


### PR DESCRIPTION
Add two new execution modes to MCPC:
- dynamic_prompting: Two-stage interaction where users first select a tool, then provide parameters
- dynamic_toolchange: Runtime tool enabling/disabling with client notifications

Includes new examples demonstrating both modes and supporting executor implementations for improved tool management and reduced parameter confusion.

closes #8 