### PR TITLE
feat: update plugin-code-execution to version 0.0.4 and change mode t…

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -20,6 +20,7 @@
     "npm:@ai-sdk/provider@2": "2.0.0",
     "npm:@hono/zod-openapi@~0.19.2": "0.19.10_hono@4.9.10_zod@3.25.76",
     "npm:@mcpc-tech/handle-sandbox@^0.0.7": "0.0.7",
+    "npm:@mcpc-tech/plugin-code-execution@^0.0.3": "0.0.3_@opentelemetry+api@1.9.0_ajv@8.17.1",
     "npm:@mcpc-tech/ripgrep-napi@^0.0.4": "0.0.4",
     "npm:@modelcontextprotocol/sdk@^1.8.0": "1.17.5_express@5.1.0_zod@3.25.76",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
@@ -257,6 +258,29 @@
         "deno"
       ],
       "tarball": "https://mirrors.tencent.com/npm/@mcpc-tech/handle-sandbox/-/handle-sandbox-0.0.7.tgz"
+    },
+    "@mcpc-tech/plugin-code-execution@0.0.3_@opentelemetry+api@1.9.0_ajv@8.17.1": {
+      "integrity": "sha512-kfefq7H1CvmGEzzfytK3HY6bDwXJpddAHDwQnS0PZ+x+F9hYIu1tGtN/OTC8cD/dK59kpPkeZv1sek3YZ4ZHmg==",
+      "dependencies": [
+        "@mcpc-tech/handle-sandbox",
+        "@mcpc-tech/ripgrep-napi",
+        "@modelcontextprotocol/sdk",
+        "@opentelemetry/api",
+        "@opentelemetry/exporter-trace-otlp-http",
+        "@opentelemetry/resources@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/sdk-trace-node",
+        "@opentelemetry/semantic-conventions@1.38.0",
+        "@segment/ajv-human-errors",
+        "ajv@8.17.1",
+        "ajv-formats",
+        "cheerio",
+        "json-schema-to-zod",
+        "json-schema-traverse@1.0.0",
+        "jsonrepair",
+        "zod"
+      ],
+      "tarball": "https://mirrors.tencent.com/npm/@mcpc-tech/plugin-code-execution/-/plugin-code-execution-0.0.3.tgz"
     },
     "@mcpc-tech/ripgrep-napi-android-arm-eabi@0.0.4": {
       "integrity": "sha512-Y52S9IdbqMYvet7hDGk/DRdKFM7ED6tSQmBtrWVzdeqVWPMayZvrKdlcceBykdKjbmgnlqtulzEtHBF2iXmXwA==",
@@ -1575,6 +1599,7 @@
           "jsr:@std/assert@^1.0.14",
           "jsr:@std/http@^1.0.14",
           "npm:@hono/zod-openapi@~0.19.2",
+          "npm:@mcpc-tech/plugin-code-execution@^0.0.3",
           "npm:@mcpc-tech/ripgrep-napi@^0.0.4",
           "npm:@modelcontextprotocol/sdk@^1.8.0",
           "npm:hono@^4.7.5",
@@ -1624,7 +1649,7 @@
       },
       "packages/plugin-code-execution": {
         "dependencies": [
-          "jsr:@mcpc/core@~0.3.4",
+          "jsr:@mcpc/core@~0.3.5",
           "jsr:@std/assert@1",
           "npm:@mcpc-tech/handle-sandbox@^0.0.7",
           "npm:@modelcontextprotocol/sdk@^1.8.0"

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpc/core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mcpc-tech/mcpc.git"

--- a/packages/core/src/prompts/types.ts
+++ b/packages/core/src/prompts/types.ts
@@ -34,7 +34,7 @@ export type ExecutionMode =
   | "agentic_workflow"
   | "agentic_sampling"
   | "agentic_workflow_sampling"
-  | "custom";
+  | (string & Record<never, never>);
 
 /**
  * Prompt template configuration

--- a/packages/plugin-code-execution/README.md
+++ b/packages/plugin-code-execution/README.md
@@ -67,7 +67,7 @@ const server = await mcpc(
       }),
     ],
     options: {
-      mode: "custom",
+      mode: "code_execution",
     },
   }],
 );

--- a/packages/plugin-code-execution/deno.json
+++ b/packages/plugin-code-execution/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpc/plugin-code-execution",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mcpc-tech/mcpc.git"
@@ -13,7 +13,7 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.8.0",
-    "@mcpc/core": "jsr:@mcpc/core@^0.3.4",
+    "@mcpc/core": "jsr:@mcpc/core@^0.3.5",
     "@mcpc-tech/handle-sandbox": "npm:@mcpc-tech/handle-sandbox@^0.0.7"
   },
   "publish": {

--- a/packages/plugin-code-execution/examples/basic-usage.ts
+++ b/packages/plugin-code-execution/examples/basic-usage.ts
@@ -42,7 +42,7 @@ The code can call MCP tools via \`callMCPTool(toolName, params)\` function.`,
       }),
     ],
     options: {
-      mode: "custom" as const,
+      mode: "code_execution" as const,
     },
   },
 ];

--- a/packages/plugin-code-execution/src/plugin.ts
+++ b/packages/plugin-code-execution/src/plugin.ts
@@ -23,7 +23,7 @@ export function createCodeExecutionPlugin(
   return {
     name: "code_execution",
     version: "1.0.0",
-    apply: "custom",
+    apply: "code_execution",
 
     registerAgentTool: (context: AgentToolRegistrationContext) => {
       const { server, name, description, allToolNames } = context;

--- a/packages/plugin-code-execution/tests/code_execution.test.ts
+++ b/packages/plugin-code-execution/tests/code_execution.test.ts
@@ -23,7 +23,7 @@ Deno.test(
           deps: { mcpServers: {} },
           plugins: [createCodeExecutionPlugin()],
           options: {
-            mode: "custom",
+            mode: "code_execution",
           },
         },
       ],
@@ -61,7 +61,7 @@ Deno.test(
           deps: { mcpServers: {} },
           plugins: [createCodeExecutionPlugin()],
           options: {
-            mode: "custom",
+            mode: "code_execution",
           },
         },
       ],
@@ -99,7 +99,7 @@ Deno.test(
           deps: { mcpServers: {} },
           plugins: [createCodeExecutionPlugin()],
           options: {
-            mode: "custom",
+            mode: "code_execution",
           },
         },
       ],


### PR DESCRIPTION
This pull request updates the code execution plugin and its dependencies to use a standardized execution mode identifier. The main change is the replacement of the previously used custom string `"custom"` with the new explicit mode `"code_execution"` throughout the plugin, examples, documentation, and tests. Additionally, the plugin and core package versions are bumped to reflect these changes.

**Standardization of execution mode:**

* Replaced all instances of `mode: "custom"` with `mode: "code_execution"` in the plugin application logic (`plugin.ts`), examples (`examples/basic-usage.ts`), documentation (`README.md`), and tests (`code_execution.test.ts`). This ensures consistent identification and usage of the code execution mode across the codebase. [[1]](diffhunk://#diff-85232a162a7bf9394c485e0817181d7b5ee3309e61d51cf21b5f0c07f2c51df2L26-R26) [[2]](diffhunk://#diff-a9c685e17525b24f72c5375f72296781345ca01a50d996d14cc4986d387f0147L45-R45) [[3]](diffhunk://#diff-1d28565c14a03ce060e254facdf01ea8e4efffc2fb6a21eae460df54da248900L70-R70) [[4]](diffhunk://#diff-9caba91a9ea7603480b2343a9e8811376eb94f0c9e35e3abbcaffb9c2eb686c9L26-R26) [[5]](diffhunk://#diff-9caba91a9ea7603480b2343a9e8811376eb94f0c9e35e3abbcaffb9c2eb686c9L64-R64) [[6]](diffhunk://#diff-9caba91a9ea7603480b2343a9e8811376eb94f0c9e35e3abbcaffb9c2eb686c9L102-R102)

* Updated the `ExecutionMode` type definition in `types.ts` to allow any string value, removing the special `"custom"` literal and supporting future extensibility.

**Version updates:**

* Bumped the version of the `@mcpc/core` package from `0.3.4` to `0.3.5` in both its own manifest and as a dependency in the plugin. [[1]](diffhunk://#diff-152fc2ff5a3d7fe31cfeec6f035866472d0d5df4f885857fcf232ab36b3d2ccaL3-R3) [[2]](diffhunk://#diff-7d0ae08b6fc0eeb06a937704eeca37fa7de66abd3b30aa86e5c6b4677ba7a231L16-R16)
* Bumped the version of the `@mcpc/plugin-code-execution` package from `0.0.3` to `0.0.4`.