### PR TITLE
feat(acp-ai-provider): add loadSession support and capability checker

### DIFF
--- a/packages/acp-ai-provider/examples/check-capabilities.ts
+++ b/packages/acp-ai-provider/examples/check-capabilities.ts
@@ -1,0 +1,168 @@
+/**
+ * Check agent capabilities for multiple ACP agents
+ *
+ * Run: deno run -A packages/acp-ai-provider/examples/check-capabilities.ts
+ */
+
+import {
+  ClientSideConnection,
+  type InitializeResponse,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+} from "@agentclientprotocol/sdk";
+import { type ChildProcess, spawn } from "node:child_process";
+import process from "node:process";
+import { Readable, Writable } from "node:stream";
+
+interface AgentConfig {
+  name: string;
+  command: string;
+  args: string[];
+}
+
+const AGENTS: AgentConfig[] = [
+  { name: "Claude Code ACP", command: "claude-code-acp", args: [] },
+  { name: "Codex ACP", command: "codex-acp", args: [] },
+  { name: "Gemini ACP", command: "gemini", args: ["--experimental-acp"] },
+];
+
+// Extended type to include agentInfo which is present in actual responses
+interface ExtendedInitializeResponse extends InitializeResponse {
+  agentInfo?: {
+    name?: string;
+    title?: string;
+    version?: string;
+  };
+}
+
+async function checkAgent(config: AgentConfig): Promise<{
+  name: string;
+  success: boolean;
+  error?: string;
+  capabilities?: ExtendedInitializeResponse;
+}> {
+  let agentProcess: ChildProcess | null = null;
+
+  try {
+    agentProcess = spawn(config.command, config.args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: process.cwd(),
+    });
+
+    if (!agentProcess.stdin || !agentProcess.stdout) {
+      throw new Error("Failed to spawn process with stdio");
+    }
+
+    const input = Writable.toWeb(agentProcess.stdin) as WritableStream<
+      Uint8Array
+    >;
+    const output = Readable.toWeb(agentProcess.stdout) as ReadableStream<
+      Uint8Array
+    >;
+
+    const connection = new ClientSideConnection(
+      () => ({
+        sessionUpdate: () => Promise.resolve(),
+        requestPermission: () =>
+          Promise.resolve({
+            outcome: { outcome: "selected", optionId: "allow" },
+          }),
+        writeTextFile: () => {
+          throw new Error("Not implemented");
+        },
+        readTextFile: () => {
+          throw new Error("Not implemented");
+        },
+      }),
+      ndJsonStream(input, output),
+    );
+
+    // Add timeout
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Timeout after 10s")), 10000)
+    );
+
+    const initResult = await Promise.race([
+      connection.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+          terminal: false,
+        },
+      }),
+      timeoutPromise,
+    ]);
+
+    return {
+      name: config.name,
+      success: true,
+      capabilities: initResult,
+    };
+  } catch (err) {
+    return {
+      name: config.name,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (agentProcess) {
+      agentProcess.kill();
+    }
+  }
+}
+
+function formatBoolean(value: boolean | undefined): string {
+  if (value === true) return "✅";
+  if (value === false) return "❌";
+  return "—";
+}
+
+async function main() {
+  console.log("=== ACP Agent Capabilities Check ===\n");
+  console.log("Checking agents...\n");
+
+  const results = await Promise.all(AGENTS.map(checkAgent));
+
+  // Build table data
+  const tableData: Record<string, Record<string, string>> = {};
+
+  for (const result of results) {
+    if (!result.success) {
+      tableData[result.name] = {
+        Status: `❌ ${result.error}`,
+        Version: "—",
+        loadSession: "—",
+        Image: "—",
+        Audio: "—",
+        EmbeddedContext: "—",
+        "MCP HTTP": "—",
+        "MCP SSE": "—",
+      };
+      continue;
+    }
+
+    const caps = result.capabilities!;
+    const agentCaps = caps.agentCapabilities;
+    const promptCaps = agentCaps?.promptCapabilities;
+    const mcpCaps = agentCaps?.mcpCapabilities;
+
+    tableData[result.name] = {
+      Status: "✅ OK",
+      Version: caps.agentInfo?.version ?? "—",
+      loadSession: formatBoolean(agentCaps?.loadSession),
+      Image: formatBoolean(promptCaps?.image),
+      Audio: formatBoolean(promptCaps?.audio),
+      EmbeddedContext: formatBoolean(promptCaps?.embeddedContext),
+      "MCP HTTP": formatBoolean(mcpCaps?.http),
+      "MCP SSE": formatBoolean(mcpCaps?.sse),
+    };
+  }
+
+  console.log("=== Agent Capabilities ===\n");
+  console.table(tableData);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/acp-ai-provider/examples/load-session-test.ts
+++ b/packages/acp-ai-provider/examples/load-session-test.ts
@@ -1,0 +1,156 @@
+/**
+ * Test script to understand loadSession behavior
+ *
+ * This script tests how loadSession replays message history via sessionUpdate notifications.
+ *
+ * The ACP protocol specifies that when loadSession is called, the agent should:
+ * 1. Restore the session context and conversation history
+ * 2. Connect to the specified MCP servers
+ * 3. Stream the entire conversation history back to the client via notifications
+ *
+ * Run: deno run -A packages/acp-ai-provider/examples/load-session-test.ts
+ */
+
+import { createACPProvider } from "../src/provider.ts";
+import { streamText } from "ai";
+import process from "node:process";
+
+async function main() {
+  console.log("=== Load Session History Replay Test ===\n");
+  console.log(
+    "This test demonstrates how loadSession captures replayed history.\n",
+  );
+
+  // Step 1: Create a new session and have a conversation
+  console.log("=== Step 1: Creating new session ===\n");
+
+  const provider1 = createACPProvider({
+    command: "claude-code-acp",
+    args: [],
+    session: {
+      cwd: process.cwd(),
+      mcpServers: [],
+    },
+    persistSession: true,
+  });
+
+  const session1 = await provider1.initSession();
+  console.log(`Session created: ${session1.sessionId}\n`);
+
+  // Step 2: Send a message
+  console.log("=== Step 2: Sending first message ===\n");
+  console.log('User: "My name is TestUser. Just say Hello TestUser."\n');
+
+  const { textStream: stream1 } = streamText({
+    model: provider1.languageModel(),
+    prompt: "My name is TestUser. Just say 'Hello TestUser' and nothing else.",
+    tools: provider1.tools,
+  });
+
+  console.log("Assistant: ");
+  for await (const chunk of stream1) {
+    process.stdout.write(chunk);
+  }
+  console.log("\n");
+
+  // Get the session ID for later
+  const sessionId = provider1.getSessionId();
+  console.log(`Session ID to resume: ${sessionId}\n`);
+
+  // Cleanup first provider
+  provider1.cleanup();
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  // Step 3: Create a new provider with existingSessionId to load the session
+  console.log("=== Step 3: Loading session with new provider ===\n");
+  console.log("Creating new provider with existingSessionId...\n");
+
+  const provider2 = createACPProvider({
+    command: "claude-code-acp",
+    args: [],
+    session: {
+      cwd: process.cwd(),
+      mcpServers: [],
+    },
+    existingSessionId: sessionId!,
+    persistSession: true,
+  });
+
+  // Initialize the session - this triggers loadSession
+  await provider2.initSession();
+
+  // Check what history was replayed
+  const replayedHistory = provider2.getReplayedHistory();
+  console.log(
+    `Collected ${replayedHistory.length} sessionUpdate notifications during loadSession.\n`,
+  );
+
+  if (replayedHistory.length > 0) {
+    console.log("History replay detected! Notification types received:");
+    const typeCounts: Record<string, number> = {};
+    for (const notification of replayedHistory) {
+      const type = notification.update.sessionUpdate;
+      typeCounts[type] = (typeCounts[type] || 0) + 1;
+    }
+    for (const [type, count] of Object.entries(typeCounts)) {
+      console.log(`  - ${type}: ${count}`);
+    }
+
+    // Convert to AI SDK messages
+    const messages = provider2.getReplayedHistoryAsMessages();
+    console.log(`\nConverted to ${messages.length} AI SDK messages:`);
+    for (const msg of messages) {
+      console.log(`  - role: ${msg.role}`);
+      if (typeof msg.content === "string") {
+        console.log(`    content: "${msg.content.slice(0, 100)}..."`);
+      } else if (Array.isArray(msg.content)) {
+        console.log(`    content: [${msg.content.length} parts]`);
+      }
+    }
+  } else {
+    console.log(
+      "No history was replayed via sessionUpdate notifications during loadSession.",
+    );
+    console.log(
+      "This means the agent handles history internally without notifying the client.",
+    );
+    console.log(
+      "The isFreshSession=false approach is correct - only send new user messages.",
+    );
+  }
+
+  // Step 4: Send another message to verify context is preserved
+  console.log("\n=== Step 4: Testing context preservation ===\n");
+  console.log('User: "What is my name?"\n');
+
+  const { textStream: stream2 } = streamText({
+    model: provider2.languageModel(),
+    prompt: "What is my name? Just say the name.",
+    tools: provider2.tools,
+  });
+
+  console.log("Assistant: ");
+  for await (const chunk of stream2) {
+    process.stdout.write(chunk);
+  }
+  console.log("\n");
+
+  // Cleanup
+  provider2.cleanup();
+
+  console.log("=== Test Complete ===\n");
+  console.log("Summary:");
+  console.log("- If history was replayed during loadSession, the client can");
+  console.log(
+    "  use getReplayedHistory() or getReplayedHistoryAsMessages() to access it.",
+  );
+  console.log(
+    "- If no history was replayed, the agent handles history internally",
+  );
+  console.log("  and the current isFreshSession=false approach is correct.");
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/acp-ai-provider/src/convert-utils.ts
+++ b/packages/acp-ai-provider/src/convert-utils.ts
@@ -1,11 +1,14 @@
-import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type {
+  ContentBlock,
+  SessionNotification,
+} from "@agentclientprotocol/sdk";
 import type {
   LanguageModelV3CallOptions,
   LanguageModelV3FunctionTool,
   LanguageModelV3ProviderTool,
 } from "@ai-sdk/provider";
 import { extractBase64Data } from "./utils.ts";
-import { asSchema, type Tool } from "ai";
+import { asSchema, type ModelMessage, type Tool } from "ai";
 import { getExecuteByName, hasRegisteredExecute } from "./acp-tool.ts";
 
 const ROLE_PREFIXES: Record<string, string> = {
@@ -156,4 +159,203 @@ export function extractACPTools(
   }
 
   return acpTools;
+}
+
+/**
+ * Converts ACP session notifications (replayed history) to AI SDK CoreMessage format.
+ *
+ * This function processes the sessionUpdate notifications that an ACP agent sends
+ * during loadSession to replay conversation history. It groups related notifications
+ * into proper AI SDK message structures.
+ *
+ * Supported notification types:
+ * - user_message_chunk -> user message
+ * - agent_message_chunk -> assistant message (text)
+ * - agent_thought_chunk -> assistant message (reasoning, if supported)
+ * - tool_call -> assistant message (tool call)
+ * - tool_call_update (completed/failed) -> tool message (result)
+ *
+ * @param notifications - Array of SessionNotification from loadSession
+ * @returns Array of ModelMessage suitable for AI SDK
+ */
+export function convertAcpHistoryToAiSdk(
+  notifications: SessionNotification[],
+): ModelMessage[] {
+  const messages: ModelMessage[] = [];
+
+  // Accumulators for building messages
+  let currentUserText = "";
+  let currentAssistantText = "";
+  let currentReasoningText = "";
+  const pendingToolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    args: unknown;
+  }> = [];
+  const pendingToolResults: Array<{
+    toolCallId: string;
+    toolName: string;
+    result: unknown;
+    isError?: boolean;
+  }> = [];
+
+  // Helper to flush accumulated user message
+  const flushUserMessage = () => {
+    if (currentUserText.trim()) {
+      messages.push({
+        role: "user",
+        content: currentUserText.trim(),
+      });
+      currentUserText = "";
+    }
+  };
+
+  // Helper to flush accumulated assistant message
+  const flushAssistantMessage = () => {
+    if (currentAssistantText.trim() || pendingToolCalls.length > 0) {
+      const content: any[] = [];
+
+      if (currentAssistantText.trim()) {
+        content.push({
+          type: "text",
+          text: currentAssistantText.trim(),
+        });
+      }
+
+      // Add reasoning if present (AI SDK experimental feature)
+      if (currentReasoningText.trim()) {
+        content.push({
+          type: "reasoning",
+          text: currentReasoningText.trim(),
+        });
+      }
+
+      // Add tool calls
+      for (const tc of pendingToolCalls) {
+        content.push({
+          type: "tool-call",
+          toolCallId: tc.toolCallId,
+          toolName: tc.toolName,
+          args: tc.args,
+        });
+      }
+
+      messages.push({
+        role: "assistant",
+        content: content.length === 1 && content[0].type === "text"
+          ? content[0].text
+          : content,
+      } as ModelMessage);
+
+      currentAssistantText = "";
+      currentReasoningText = "";
+      pendingToolCalls.length = 0;
+    }
+  };
+
+  // Helper to flush tool results as tool message
+  const flushToolResults = () => {
+    if (pendingToolResults.length > 0) {
+      messages.push({
+        role: "tool",
+        content: pendingToolResults.map((tr) => ({
+          type: "tool-result",
+          toolCallId: tr.toolCallId,
+          toolName: tr.toolName,
+          output: tr.result, // AI SDK uses 'output' not 'result'
+          isError: tr.isError,
+        })),
+      } as ModelMessage);
+      pendingToolResults.length = 0;
+    }
+  };
+
+  for (const notification of notifications) {
+    const update = notification.update;
+
+    switch (update.sessionUpdate) {
+      case "user_message_chunk": {
+        // Flush any pending assistant/tool messages before user message
+        flushAssistantMessage();
+        flushToolResults();
+
+        if (update.content.type === "text") {
+          currentUserText += update.content.text;
+        }
+        break;
+      }
+
+      case "agent_message_chunk": {
+        // Flush user message if we're starting assistant response
+        flushUserMessage();
+
+        if (update.content.type === "text") {
+          currentAssistantText += update.content.text;
+        }
+        break;
+      }
+
+      case "agent_thought_chunk": {
+        // Reasoning/thinking content
+        flushUserMessage();
+
+        if (update.content.type === "text") {
+          currentReasoningText += update.content.text;
+        }
+        break;
+      }
+
+      case "tool_call": {
+        // Flush user message, accumulate tool call
+        flushUserMessage();
+
+        const toolCallId = update.toolCallId;
+        const toolName = update.title || toolCallId;
+        const args = update.rawInput ?? {};
+
+        // Only add if we have actual input (not just a pending notification)
+        if (args && Object.keys(args as object).length > 0) {
+          pendingToolCalls.push({
+            toolCallId,
+            toolName,
+            args,
+          });
+        }
+        break;
+      }
+
+      case "tool_call_update": {
+        const status = update.status;
+
+        // Only process completed/failed tool calls
+        if (status === "completed" || status === "failed") {
+          // Flush assistant message with tool calls before adding results
+          flushAssistantMessage();
+
+          const toolCallId = update.toolCallId;
+          const toolName = update.title || toolCallId;
+          const result = update.rawOutput ?? update.content ?? null;
+
+          pendingToolResults.push({
+            toolCallId,
+            toolName,
+            result,
+            isError: status === "failed",
+          });
+        }
+        break;
+      }
+
+      // Ignore other notification types (plan, available_commands_update, etc.)
+      default:
+        break;
+    }
+  }
+
+  // Flush any remaining accumulated content
+  flushUserMessage();
+  flushAssistantMessage();
+  flushToolResults();
+
+  return messages;
 }

--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -26,12 +26,13 @@ import { type ChildProcess, spawn } from "node:child_process";
 import process from "node:process";
 import { Readable, Writable } from "node:stream";
 import type { ACPProviderSettings } from "./types.ts";
-import type { Tool, tool } from "ai";
+import type { ModelMessage, Tool, tool } from "ai";
 import z from "zod";
 import { formatToolError } from "./format-tool-error.ts";
 import { ToolProxyHost } from "./tool-proxy/mod.ts";
 import { getACPDynamicTool } from "./acp-tool.ts";
 import {
+  convertAcpHistoryToAiSdk,
   convertAiSdkMessagesToAcp,
   extractACPTools,
   type ToolsInput,
@@ -156,6 +157,9 @@ export class ACPLanguageModel implements LanguageModelV3 {
 
   // Tool proxy for host-side tool execution
   private toolProxyHost: ToolProxyHost | null = null;
+
+  // History replayed during loadSession (per ACP protocol)
+  private replayedHistory: SessionNotification[] = [];
 
   constructor(
     modelId: string | undefined,
@@ -373,18 +377,35 @@ export class ACPLanguageModel implements LanguageModelV3 {
 
     // Start a fresh session
     if (this.config.existingSessionId) {
+      // Set up handler to capture history replayed during loadSession
+      // Per ACP protocol, loadSession should stream conversation history via sessionUpdate
+      this.replayedHistory = [];
+      if (this.client) {
+        this.client.setSessionUpdateHandler((notification) => {
+          this.replayedHistory.push(notification);
+        });
+      }
+
       // Note: loadSession typically assumes servers are already known or config is separate?
       // Protocol says loadSession usually just resumes.
       // But if we want to Add tools to a loaded session, we might need newSession logic?
       // For now, preserving original logic: loadSession takes mcpServers.
-      await this.connection.loadSession({
+      const loadResponse = await this.connection.loadSession({
         sessionId: this.config.existingSessionId,
         cwd: this.config.session?.cwd ?? process.cwd(),
         mcpServers,
       });
       this.sessionId = this.config.existingSessionId;
-      this.sessionResponse = { sessionId: this.config.existingSessionId };
+      this.sessionResponse = {
+        sessionId: this.config.existingSessionId,
+        ...loadResponse,
+      };
       this.isFreshSession = false;
+
+      // Clear the handler after loadSession completes
+      if (this.client) {
+        this.client.setSessionUpdateHandler(() => {});
+      }
     } else {
       this.sessionResponse = await this.connection.newSession({
         ...this.config.session,
@@ -455,6 +476,35 @@ export class ACPLanguageModel implements LanguageModelV3 {
    */
   getSessionId(): string | null {
     return this.sessionId;
+  }
+
+  /**
+   * Returns the raw session notifications replayed during loadSession.
+   * Per ACP protocol, when loading an existing session, the agent streams
+   * the conversation history via sessionUpdate notifications.
+   *
+   * This is useful for:
+   * - Displaying previous conversation to the user
+   * - Debugging session state
+   * - Custom history processing
+   *
+   * @returns Array of SessionNotification objects received during loadSession
+   */
+  getReplayedHistory(): SessionNotification[] {
+    return this.replayedHistory;
+  }
+
+  /**
+   * Returns the replayed history converted to AI SDK ModelMessage format.
+   * This allows integrating the history into the AI SDK message array.
+   *
+   * Note: The conversion may be lossy as ACP notifications don't map 1:1 to AI SDK messages.
+   * Tool calls and results are grouped into assistant/tool messages.
+   *
+   * @returns Array of ModelMessage objects suitable for AI SDK
+   */
+  getReplayedHistoryAsMessages(): ModelMessage[] {
+    return convertAcpHistoryToAiSdk(this.replayedHistory);
   }
 
   /**

--- a/packages/acp-ai-provider/src/provider.ts
+++ b/packages/acp-ai-provider/src/provider.ts
@@ -3,9 +3,12 @@
  */
 
 import { ACPLanguageModel } from "./language-model.ts";
-import type { tool } from "ai";
+import type { ModelMessage, tool } from "ai";
 import type { ACPProviderSettings } from "./types.ts";
-import type { NewSessionResponse } from "@agentclientprotocol/sdk";
+import type {
+  NewSessionResponse,
+  SessionNotification,
+} from "@agentclientprotocol/sdk";
 
 /**
  * ACP Provider - implements AI SDK provider pattern
@@ -59,6 +62,30 @@ export class ACPProvider {
    */
   getSessionId(): string | null {
     return this.model?.getSessionId() ?? null;
+  }
+
+  /**
+   * Returns the raw session notifications replayed during loadSession.
+   * Per ACP protocol, when loading an existing session, the agent streams
+   * the conversation history via sessionUpdate notifications.
+   *
+   * @returns Array of SessionNotification objects received during loadSession
+   */
+  getReplayedHistory(): SessionNotification[] {
+    return this.model?.getReplayedHistory() ?? [];
+  }
+
+  /**
+   * Returns the replayed history converted to AI SDK ModelMessage format.
+   * This allows integrating the history into the AI SDK message array.
+   *
+   * Note: The conversion may be lossy as ACP notifications don't map 1:1 to AI SDK messages.
+   * Tool calls and results are grouped into assistant/tool messages.
+   *
+   * @returns Array of ModelMessage objects suitable for AI SDK
+   */
+  getReplayedHistoryAsMessages(): ModelMessage[] {
+    return this.model?.getReplayedHistoryAsMessages() ?? [];
   }
 
   /**

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -21,16 +21,16 @@ function createProviderSettings(
   };
 }
 
-Deno.test("ACPLanguageModel - implements LanguageModelV2 interface", () => {
+Deno.test("ACPLanguageModel - implements LanguageModelV3 interface", () => {
   const model = new ACPLanguageModel(
     "test-agent",
     undefined,
     createProviderSettings(),
   );
 
-  // Check required LanguageModelV2 properties
+  // Check required LanguageModelV3 properties
   assertEquals(model.modelId, "test-agent");
-  assertEquals(model.specificationVersion, "v2");
+  assertEquals(model.specificationVersion, "v3");
   assertEquals(model.provider, "acp");
   assertEquals(typeof model.doGenerate, "function");
   assertEquals(typeof model.doStream, "function");
@@ -140,5 +140,5 @@ Deno.test("ACPLanguageModel - model properties are consistent", () => {
   assertEquals(model.modelId, modelId);
   assertEquals(model.modelId, "my-model-123");
   assertEquals(model.provider, "acp");
-  assertEquals(model.specificationVersion, "v2");
+  assertEquals(model.specificationVersion, "v3");
 });


### PR DESCRIPTION
- Add convertAcpHistoryToAiSdk function to convert ACP session history to AI SDK messages
- Add loadSession example (load-session-test.ts)
- Add multi-agent capability checker (check-capabilities.ts)

Note: Currently no mainstream ACP agents support loadSession capability