### PR TITLE
refactor(mcpc): simplify API with AgentOptions and add defaults

### DIFF
--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { registerAgent } from "./controllers/register.ts";
-import { mcpc } from "@mcpc/core";
+import { mcpcLegacy } from "@mcpc/core";
 import { createLargeResultPlugin } from "@mcpc/core/plugins/large-result";
 import type { ComposableMCPServer, ComposeDefinition } from "@mcpc/core";
 import type { MCPCConfig } from "./config/loader.ts";
@@ -25,7 +25,7 @@ export const createServer = async (
     ] as ComposeDefinition[],
   };
 
-  return await mcpc(
+  return await mcpcLegacy(
     [
       {
         name: serverConfig.name || "mcpc-server",

--- a/packages/core/examples/01-basic-composition.ts
+++ b/packages/core/examples/01-basic-composition.ts
@@ -11,20 +11,27 @@
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { type ComposeDefinition, mcpc } from "../mod.ts";
+import { mcpc } from "../mod.ts";
 
-export const toolDefinitions: ComposeDefinition[] = [
-  {
-    name: "file-organizer",
-    description:
-      `I am a smart file organizer that helps users manage their files efficiently.
+export const server = await mcpc({
+  name: "basic-file-manager",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  agents: [
+    {
+      name: "file-organizer",
+      description:
+        `I am a smart file organizer that helps users manage their files efficiently.
 
 Available tools:
 <tool name="@wonderwhy-er/desktop-commander.list_directory"/>
 <tool name="@wonderwhy-er/desktop-commander.create_directory"/>
 <tool name="@wonderwhy-er/desktop-commander.move_file"/>
 <tool name="@wonderwhy-er/desktop-commander.read_file"/>
-<tool name="@wonderwhy-er/desktop-commander.write_file">
+<tool name="@wonderwhy-er/desktop-commander.write_file"/>
 
 I can:
 1. List directory contents to understand the current file structure
@@ -36,34 +43,15 @@ I can:
 
 I always ask for confirmation before making destructive changes and provide clear explanations of what I'm doing.`,
 
-    deps: {
       mcpServers: {
         "@wonderwhy-er/desktop-commander": {
           command: "npx",
           args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
-          transportType: "stdio" as const,
-        },
-      },
-    },
-  },
-];
-
-export const server = await mcpc(
-  [
-    {
-      name: "basic-file-manager",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {
-          listChanged: true,
         },
       },
     },
   ],
-  toolDefinitions,
-);
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/core/examples/02-agentic-data-analyst.ts
+++ b/packages/core/examples/02-agentic-data-analyst.ts
@@ -14,22 +14,15 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { mcpc } from "../mod.ts";
 
-export const server = await mcpc(
-  [
-    {
-      name: "agentic-data-analyst",
-      version: "1.0.0",
-    },
-    { capabilities: { tools: { listChanged: true } } },
-  ],
-  [
+export const server = await mcpc({
+  name: "agentic-data-analyst",
+  version: "1.0.0",
+  capabilities: { tools: { listChanged: true } },
+
+  agents: [
     {
       name: "data-analyst",
-
-      // Agentic mode for complete autonomy
-      options: {
-        mode: "agentic",
-      },
+      mode: "agentic",
 
       description:
         `I am an autonomous data analyst that can perform comprehensive data analysis with complete freedom to orchestrate my actions.
@@ -60,22 +53,18 @@ I decide the order of operations dynamically based on:
 
 My autonomous approach ensures thorough analysis tailored to each unique dataset.`,
 
-      deps: {
-        mcpServers: {
-          "code-runner": {
-            command: "deno",
-            args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
-            transportType: "stdio",
-          },
-          "@wonderwhy-er/desktop-commander": {
-            command: "npx",
-            args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
-            transportType: "stdio",
-          },
+      mcpServers: {
+        "code-runner": {
+          command: "deno",
+          args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
+        },
+        "@wonderwhy-er/desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
         },
       },
     },
   ],
-);
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/core/examples/06-multi-mcp-web-analyzer.ts
+++ b/packages/core/examples/06-multi-mcp-web-analyzer.ts
@@ -15,21 +15,15 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { mcpc } from "../mod.ts";
 
-export const server = await mcpc(
-  [
-    {
-      name: "multi-mcp-web-analyzer",
-      version: "1.0.0",
-    },
-    { capabilities: { tools: { listChanged: true } } },
-  ],
-  [
+export const server = await mcpc({
+  name: "multi-mcp-web-analyzer",
+  version: "1.0.0",
+  capabilities: { tools: { listChanged: true } },
+
+  agents: [
     {
       name: "web-analyzer",
-
-      options: {
-        mode: "agentic",
-      },
+      mode: "agentic",
 
       description:
         `I am a comprehensive web analyzer that combines multiple MCP servers to perform sophisticated web content analysis and reporting.
@@ -83,27 +77,22 @@ I intelligently coordinate between browser automation, data processing, and file
 - PDF reports for sharing and presentation
 - Screenshots and visual documentation`,
 
-      deps: {
-        mcpServers: {
-          "@microsoft/playwright-mcp": {
-            command: "npx",
-            args: ["@playwright/mcp@latest", "--image-responses=emit"],
-            transportType: "stdio",
-          },
-          "code-runner": {
-            command: "deno",
-            args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
-            transportType: "stdio",
-          },
-          "@wonderwhy-er/desktop-commander": {
-            command: "npx",
-            args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
-            transportType: "stdio",
-          },
+      mcpServers: {
+        "@microsoft/playwright-mcp": {
+          command: "npx",
+          args: ["@playwright/mcp@latest", "--image-responses=emit"],
+        },
+        "code-runner": {
+          command: "deno",
+          args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
+        },
+        "@wonderwhy-er/desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
         },
       },
     },
   ],
-);
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/core/examples/07-runtime-transformations.ts
+++ b/packages/core/examples/07-runtime-transformations.ts
@@ -119,15 +119,17 @@ const _errorEnrichmentPlugin: ToolPlugin = {
 
 // Example usage
 async function main() {
-  const server = await mcpc(
-    [{ name: "example-server", version: "1.0.0" }, {}],
-    [],
-    async (server) => {
-      // Add runtime transformation plugins
-      await server.addPlugin(inputSanitizationPlugin);
-      await server.addPlugin(outputFormattingPlugin);
-      await server.addPlugin(loggingPlugin);
+  const server = await mcpc({
+    name: "example-server",
+    version: "1.0.0",
 
+    plugins: [
+      inputSanitizationPlugin,
+      outputFormattingPlugin,
+      loggingPlugin,
+    ],
+
+    setup: (server) => {
       // Register a sample tool
       server.tool(
         "greet",
@@ -151,7 +153,7 @@ async function main() {
         },
       );
     },
-  );
+  });
 
   // Test the tool - input will be sanitized, output will be formatted and logged
   const result = await server.callTool("greet", {

--- a/packages/core/examples/09-unified-prompt-management.ts
+++ b/packages/core/examples/09-unified-prompt-management.ts
@@ -98,37 +98,31 @@ const agentDescription = fileOperationsDescription
   .replace("{hiddenTools}", hiddenTools)
   .replace("{wildcardTools}", wildcardTools);
 
-export const server = await mcpc(
-  [
-    {
-      name: "unified-prompt-manager",
-      version: "1.0.0",
-    },
-    { capabilities: { tools: { listChanged: true } } },
-  ],
-  [
+export const server = await mcpc({
+  name: "unified-prompt-manager",
+  version: "1.0.0",
+  capabilities: { tools: { listChanged: true } },
+
+  agents: [
     {
       name: "prompt-managed-agent",
-
-      // Use centralized description template
       description: agentDescription,
 
-      deps: {
-        mcpServers: {
-          "@wonderwhy-er/desktop-commander": {
-            command: "npx",
-            args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
-          },
-          "code-runner": {
-            command: "deno",
-            args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
-          },
+      mcpServers: {
+        "@wonderwhy-er/desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+        },
+        "code-runner": {
+          command: "deno",
+          args: ["run", "--allow-all", "jsr:@mcpc/code-runner-mcp/bin"],
         },
       },
     },
   ],
+
   // Demonstrate internal tool registration with centralized prompts
-  (server) => {
+  setup: (server) => {
     server.tool(
       "audit-logger",
       "Internal comprehensive audit logging with standardized format",
@@ -228,6 +222,6 @@ export const server = await mcpc(
       "📝 All prompts are now centrally managed and dynamically generated",
     );
   },
-);
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/core/examples/11-large-result-plugin-agentic.ts
+++ b/packages/core/examples/11-large-result-plugin-agentic.ts
@@ -6,25 +6,26 @@
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { mcpc } from "../src/set-up-mcp-compose.ts";
-// import { createLargeResultPlugin } from "../plugins.ts";
+import { mcpc } from "../mod.ts";
 import { jsonSchema } from "../mod.ts";
 
-const server = await mcpc(
-  [{ name: "large-demo", version: "1.0.0" }, { capabilities: { tools: {} } }],
-  [
+const server = await mcpc({
+  name: "large-demo",
+  version: "1.0.0",
+  capabilities: { tools: {} },
+
+  agents: [
     {
       name: "large-output-handler",
       description:
         "Agent that demonstrates automatic large output handling and file storage",
       plugins: [
         "./plugins/large-result.ts?maxSize=8000&previewSize=4000",
-        // create a large result plugin instance
-        // createLargeResultPlugin(),
       ],
     },
   ],
-  (server) => {
+
+  setup: (server) => {
     // Tool that makes big output
     server.tool(
       "make-big-text",
@@ -46,7 +47,7 @@ const server = await mcpc(
       { internal: true },
     );
   },
-);
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/core/examples/13-in-memory-transport.ts
+++ b/packages/core/examples/13-in-memory-transport.ts
@@ -13,7 +13,7 @@
 import { z } from "zod";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type ComposeDefinition, mcpc } from "../mod.ts";
+import { mcpc } from "../mod.ts";
 
 // Create a simple in-memory MCP server for demonstration
 function createTestMcpServer() {
@@ -42,10 +42,22 @@ function createTestMcpServer() {
 // Initialize the in-memory server
 const testServer = createTestMcpServer();
 
-export const toolDefinitions: ComposeDefinition[] = [
-  {
-    name: "memory-agent",
-    description:
+// Note: In-memory transport requires direct server reference which is
+// not supported in the new API's McpServerDef. For in-memory transport,
+// use the setup callback to manually compose.
+export const server = await mcpc({
+  name: "in-memory-example",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  // For in-memory transport, we need to use the setup callback
+  // since the new API doesn't have a direct way to pass server instances
+  setup: async (server) => {
+    // Use the compose method directly for in-memory transport
+    await server.compose(
+      "memory-agent",
       `I am an agent that uses in-memory transport to communicate with MCP servers.
 
 Available tools:
@@ -54,34 +66,17 @@ Available tools:
 I can greet users using the in-memory MCP server. This demonstrates how MCPC can work with 
 in-memory transports for testing and embedded scenarios where you don't want to spawn 
 external processes.`,
-
-    deps: {
-      mcpServers: {
-        "test-memory-server": {
-          transportType: "memory" as const,
-          server: testServer,
+      {
+        mcpServers: {
+          "test-memory-server": {
+            transportType: "memory" as any,
+            server: testServer,
+          } as any,
         },
       },
-    },
+    );
   },
-];
-
-export const server = await mcpc(
-  [
-    {
-      name: "in-memory-example",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {
-          listChanged: true,
-        },
-      },
-    },
-  ],
-  toolDefinitions,
-);
+});
 
 // Only run if executed directly
 if (import.meta.main) {

--- a/packages/core/examples/14-skills-plugin.ts
+++ b/packages/core/examples/14-skills-plugin.ts
@@ -16,21 +16,15 @@ import { createSkillsPlugin } from "../plugins.ts";
 // Get directory of current file for reliable relative paths
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export const server = await mcpc(
-  [
-    {
-      name: "skills-demo",
-      version: "1.0.0",
-    },
-    { capabilities: { tools: { listChanged: true } } },
-  ],
-  [
+export const server = await mcpc({
+  name: "skills-demo",
+  version: "1.0.0",
+  capabilities: { tools: { listChanged: true } },
+
+  agents: [
     {
       name: "coding-assistant",
-
-      options: {
-        mode: "agentic",
-      },
+      mode: "agentic",
 
       // Just describe the agent - skills info is in load-skill tool
       description:
@@ -43,7 +37,7 @@ export const server = await mcpc(
       ],
     },
   ],
-);
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/core/examples/15-ai-acp-mode.ts
+++ b/packages/core/examples/15-ai-acp-mode.ts
@@ -18,12 +18,19 @@
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { type ComposeDefinition, mcpc } from "../mod.ts";
+import { mcpc } from "../mod.ts";
 
-export const toolDefinitions: ComposeDefinition[] = [
-  {
-    name: "coding-assistant",
-    description: `A coding assistant powered by Claude Code ACP.
+export const server = await mcpc({
+  name: "ai-acp-coding-assistant",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  agents: [
+    {
+      name: "coding-assistant",
+      description: `A coding assistant powered by Claude Code ACP.
 
 Available tools:
 <tool name="@modelcontextprotocol/server-everything.echo"/>
@@ -33,45 +40,26 @@ I can help with:
 1. Echo messages back
 2. Perform arithmetic operations`,
 
-    deps: {
       mcpServers: {
         "@modelcontextprotocol/server-everything": {
           command: "npx",
           args: ["-y", "@modelcontextprotocol/server-everything"],
-          transportType: "stdio" as const,
         },
       },
-    },
 
-    options: {
       mode: "ai_acp",
-      acpSettings: {
-        command: "claude-code-acp",
-        args: [],
-        session: {},
-      },
-      maxSteps: 50,
-      tracingEnabled: false,
-    },
-  },
-];
-
-export const server = await mcpc(
-  [
-    {
-      name: "ai-acp-coding-assistant",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {
-          listChanged: true,
+      options: {
+        acpSettings: {
+          command: "claude-code-acp",
+          args: [],
+          session: {},
         },
+        maxSteps: 50,
+        tracingEnabled: false,
       },
     },
   ],
-  toolDefinitions,
-);
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/core/examples/16-markdown-agent-file.ts
+++ b/packages/core/examples/16-markdown-agent-file.ts
@@ -11,17 +11,21 @@ import { mcpc } from "@mcpc/core";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { fileURLToPath } from "node:url";
 
-const server = await mcpc(
-  [{ name: "mcpc-markdown-example", version: "1.0.0" }, {
-    capabilities: { tools: {} },
-  }],
-  [fileURLToPath(
-    new URL(
-      "../../plugin-markdown-loader/examples/codex-fork.md",
-      import.meta.url,
+const server = await mcpc({
+  name: "mcpc-markdown-example",
+  version: "1.0.0",
+  capabilities: { tools: {} },
+
+  plugins: ["@mcpc/plugin-markdown-loader"],
+
+  agents: [
+    fileURLToPath(
+      new URL(
+        "../../plugin-markdown-loader/examples/codex-fork.md",
+        import.meta.url,
+      ),
     ),
-  )],
-  { plugins: ["@mcpc/plugin-markdown-loader"] }, // String-based plugin loading
-);
+  ],
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/core/examples/17-mixed-agent-sources.ts
+++ b/packages/core/examples/17-mixed-agent-sources.ts
@@ -7,31 +7,31 @@
  * ```
  */
 
-import { type ComposeDefinition, mcpc } from "@mcpc/core";
+import { type AgentDef, mcpc } from "@mcpc/core";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { fileURLToPath } from "node:url";
 
-const inlineAgent: ComposeDefinition = {
+const inlineAgent: AgentDef = {
   name: "simple-file-reader",
   description: `A simple file reading agent.
 Use <tool name="desktop-commander.read_file"/> to read files.
 Use <tool name="desktop-commander.list_directory"/> to list directories.`,
-  deps: {
-    mcpServers: {
-      "desktop-commander": {
-        command: "npx",
-        args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
-        transportType: "stdio",
-      },
+  mcpServers: {
+    "desktop-commander": {
+      command: "npx",
+      args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
     },
   },
 };
 
-const server = await mcpc(
-  [{ name: "mcpc-mixed-example", version: "1.0.0" }, {
-    capabilities: { tools: {} },
-  }],
-  [
+const server = await mcpc({
+  name: "mcpc-mixed-example",
+  version: "1.0.0",
+  capabilities: { tools: {} },
+
+  plugins: ["@mcpc/plugin-markdown-loader"],
+
+  agents: [
     inlineAgent,
     fileURLToPath(
       new URL(
@@ -40,7 +40,6 @@ const server = await mcpc(
       ),
     ),
   ],
-  { plugins: ["@mcpc/plugin-markdown-loader"] }, // String-based plugin loading
-);
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/core/examples/18-mcpc-basic.ts
+++ b/packages/core/examples/18-mcpc-basic.ts
@@ -1,0 +1,64 @@
+/**
+ * Example: MCPC - Basic Usage
+ *
+ * Demonstrates the single-configuration-object API pattern.
+ *
+ * Run:
+ * ```bash
+ * deno run --allow-all packages/core/examples/18-mcpc-basic.ts
+ * ```
+ */
+
+import { mcpc } from "@mcpc/core";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+// Clean single configuration object
+const server = await mcpc({
+  // Server configuration (flat)
+  name: "file-manager",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  // Agent definitions
+  agents: [
+    {
+      name: "file-organizer",
+      description:
+        `I am a smart file organizer that helps users manage their files efficiently.
+
+Available tools:
+<tool name="desktop-commander.list_directory"/>
+<tool name="desktop-commander.create_directory"/>
+<tool name="desktop-commander.move_file"/>
+<tool name="desktop-commander.read_file"/>
+<tool name="desktop-commander.write_file"/>
+
+I can:
+1. List directory contents to understand the current file structure
+2. Create new directories for organization
+3. Move files to appropriate folders based on type, date, or content
+4. Read file contents to understand what they contain
+5. Create new files or modify existing ones
+
+I always ask for confirmation before making destructive changes.`,
+
+      // MCP server dependencies (flat - no nested mcpServers)
+      mcpServers: {
+        "desktop-commander": {
+          command: "npx",
+          args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+          // transportType defaults to "stdio" when command is provided
+        },
+      },
+
+      // Agent-specific options (flat)
+      mode: "agentic",
+    },
+  ],
+});
+
+// Connect to transport
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/core/examples/19-mcpc-advanced.ts
+++ b/packages/core/examples/19-mcpc-advanced.ts
@@ -1,0 +1,125 @@
+/**
+ * Example: MCPC - Advanced Usage
+ *
+ * Demonstrates advanced features:
+ * - Multiple agents
+ * - Mixed sources (inline + markdown files)
+ * - Plugin configuration
+ * - Setup callback
+ * - AI SDK modes
+ *
+ * Run:
+ * ```bash
+ * deno run --allow-all packages/core/examples/19-mcpc-advanced.ts
+ * ```
+ */
+
+import { type AgentDef, mcpc } from "@mcpc/core";
+import { jsonSchema } from "@mcpc/core";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+// Define agents separately for better organization
+const fileReaderAgent: AgentDef = {
+  name: "file-reader",
+  description: `A simple file reading agent.
+<tool name="desktop-commander.read_file"/>
+<tool name="desktop-commander.list_directory"/>`,
+  mcpServers: {
+    "desktop-commander": {
+      command: "npx",
+      args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+    },
+  },
+  mode: "agentic",
+};
+
+const dataAnalystAgent: AgentDef = {
+  name: "data-analyst",
+  description: `An AI-powered data analyst using sampling mode.
+<tool name="desktop-commander.read_file"/>
+<tool name="desktop-commander.execute_command"/>`,
+  mcpServers: {
+    "desktop-commander": {
+      command: "npx",
+      args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+    },
+  },
+  mode: "ai_sampling",
+  // Advanced options grouped together
+  options: {
+    maxSteps: 30,
+    maxTokens: 64000,
+    tracingEnabled: true,
+  },
+};
+
+// Create server
+const server = await mcpc({
+  name: "multi-agent-server",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  // Multiple agents
+  agents: [
+    fileReaderAgent,
+    dataAnalystAgent,
+    // Can also include markdown file paths (requires markdown-loader plugin)
+    // fileURLToPath(new URL("../../plugin-markdown-loader/examples/codex-fork.md", import.meta.url)),
+  ],
+
+  // Global plugins
+  plugins: [
+    // String-based plugin loading
+    // "@mcpc/plugin-markdown-loader",
+
+    // Or inline plugin objects
+    {
+      name: "request-logger",
+      beforeToolExecute: (context) => {
+        console.log(`[LOG] Executing tool: ${context.toolName}`);
+        return undefined;
+      },
+      afterToolExecute: (context) => {
+        console.log(
+          `[LOG] Tool ${context.toolName} completed in ${context.executionTimeMs}ms`,
+        );
+        return undefined;
+      },
+    },
+  ],
+
+  // Setup callback for custom tools
+  setup: (server) => {
+    // Register custom internal tools
+    server.tool(
+      "get-current-time",
+      "Get the current timestamp",
+      jsonSchema<{ timezone?: string }>({
+        type: "object",
+        properties: {
+          timezone: {
+            type: "string",
+            description: "Timezone (e.g., 'America/New_York')",
+          },
+        },
+      }),
+      (_args) => {
+        const date = new Date();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Current time: ${date.toISOString()}`,
+            },
+          ],
+        };
+      },
+    );
+  },
+});
+
+// Connect to transport
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/core/examples/sampling/01-basic-composition.ts
+++ b/packages/core/examples/sampling/01-basic-composition.ts
@@ -1,7 +1,7 @@
 /**
- * MCPC Example 01: Basic File Manager
+ * MCPC Example 01: Basic File Manager (AI Sampling Mode)
  *
- * Demonstrates the fundamental MCPC features:
+ * Demonstrates the fundamental MCPC features with AI sampling mode:
  * - Basic server creation and composition
  * - Dependency management with external MCP servers
  * - Simple tool orchestration with file operations
@@ -12,16 +12,21 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { mcpc } from "../../mod.ts";
-import type { ComposeDefinition } from "../../src/set-up-mcp-compose.ts";
 
-export const toolDefinitions: ComposeDefinition[] = [
-  {
-    name: "file-organizer",
-    options: {
+export const server = await mcpc({
+  name: "basic-file-manager",
+  version: "1.0.0",
+  capabilities: {
+    tools: { listChanged: true },
+  },
+
+  agents: [
+    {
+      name: "file-organizer",
       mode: "ai_sampling",
-    },
-    description:
-      `I am a smart file organizer that helps users manage their files efficiently.
+
+      description:
+        `I am a smart file organizer that helps users manage their files efficiently.
 
 Available tools:
 <tool name="@wonderwhy-er/desktop-commander.list_directory"/>
@@ -40,34 +45,15 @@ I can:
 
 I always ask for confirmation before making destructive changes and provide clear explanations of what I'm doing.`,
 
-    deps: {
       mcpServers: {
         "@wonderwhy-er/desktop-commander": {
           command: "npx",
           args: ["-y", "@wonderwhy-er/desktop-commander"],
-          transportType: "stdio",
-        },
-      },
-    },
-  },
-];
-
-export const server = await mcpc(
-  [
-    {
-      name: "basic-file-manager",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {
-          listChanged: true,
         },
       },
     },
   ],
-  toolDefinitions,
-);
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -4,38 +4,30 @@
  * Write a simple description, select your tools, and get a working MCP server.
  *
  * ```ts
- * import { type ComposeDefinition, mcpc } from "@mcpc/core";
+ * import { mcpc } from "@mcpc/core";
  * import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
  *
- * // Define MCP server dependencies
- * const deps: ComposeDefinition['deps'] = {
- *   mcpServers: {
- *     "desktop-commander": {
- *       command: "npx",
- *       args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
- *       transportType: "stdio",
- *     }
- *   }
- * }
+ * const server = await mcpc({
+ *   name: "coding-agent",
+ *   version: "1.0.0",
  *
- * // Write agent description with tool references
- * const description = `
- * I am a coding assistant that can read files and run terminal commands.
+ *   agents: [{
+ *     name: "coding-agent",
+ *     description: `
+ *       I am a coding assistant that can read files and run terminal commands.
+ *       <tool name="desktop-commander.execute_command"/>
+ *       <tool name="desktop-commander.read_file"/>
+ *     `,
+ *     mcpServers: {
+ *       "desktop-commander": {
+ *         command: "npx",
+ *         args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
+ *       },
+ *     },
+ *   }],
+ * });
  *
- * Available tools:
- * <tool name="desktop-commander.execute_command" />
- * <tool name="desktop-commander.read_file" />
- * <tool name="desktop-commander.write_file" />
- * `
- *
- * // Create and start the server
- * const server = await mcpc(
- *   [{ name: "coding-agent", version: "1.0.0" }],
- *   [{ name: 'coding-agent', description, deps }]
- * )
- *
- * const transport = new StdioServerTransport()
- * await server.connect(transport)
+ * await server.connect(new StdioServerTransport());
  * ```
  *
  * ## Documentation
@@ -83,17 +75,29 @@ export * from "./src/utils/common/env.ts";
 export * from "./src/utils/common/json.ts";
 export * from "./src/utils/common/mcp.ts";
 
+// Legacy API - Positional arguments pattern (deprecated)
 export {
   type ComposeDefinition,
   type ComposeInput,
   type ComposibleMCPConfig,
   isMarkdownFile,
   type MarkdownAgentLoader,
-  mcpc,
+  mcpc as mcpcLegacy,
   type McpcOptions,
   parseMcpcConfigs,
   setMarkdownAgentLoader,
 } from "./src/set-up-mcp-compose.ts";
+
+// Main API - Single configuration object pattern
+export {
+  type AgentDef,
+  type AgentOptions,
+  mcpc,
+  type McpcConfig,
+  type McpServerDef,
+  registerMarkdownLoader,
+  type ServerCapabilities,
+} from "./src/mcpc.ts";
 
 // Schema utilities (replaces AI SDK dependency)
 export {

--- a/packages/core/src/mcpc.ts
+++ b/packages/core/src/mcpc.ts
@@ -1,0 +1,444 @@
+/**
+ * MCPC - Single Configuration Object Pattern
+ *
+ * A cleaner, more intuitive API inspired by AI SDK's streamText design.
+ * All configuration is provided through a single options object.
+ */
+
+import { ComposableMCPServer } from "./compose.ts";
+import type { MCPSetting } from "./service/tools.ts";
+import type { SamplingConfig, ToolRefXml } from "./types.ts";
+import type { ToolPlugin } from "./plugin-types.ts";
+import type { ExecutionMode } from "./prompts/types.ts";
+import {
+  isMarkdownFile,
+  type MarkdownAgentLoader,
+  setMarkdownAgentLoader as _setMarkdownAgentLoader,
+} from "./set-up-mcp-compose.ts";
+
+// Re-export for external use
+export { setMarkdownAgentLoader } from "./set-up-mcp-compose.ts";
+
+/**
+ * MCP Server configuration for agent dependencies.
+ * Supports stdio, sse, and streamable-http transport types.
+ */
+export interface McpServerDef {
+  /** Command to start the MCP server (for stdio transport) */
+  command?: string;
+  /** Arguments for the command */
+  args?: string[];
+  /** Environment variables */
+  env?: Record<string, string>;
+  /** Transport type - defaults to "stdio" if command is provided */
+  transportType?: "stdio" | "sse" | "streamable-http";
+  /** URL for sse or streamable-http transport */
+  url?: string;
+  /** Headers for HTTP-based transports */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Advanced options for agent execution.
+ * Most users don't need these - they're for specialized modes like AI SDK sampling.
+ */
+export interface AgentOptions {
+  /** Maximum execution steps */
+  maxSteps?: number;
+
+  /** Maximum tokens for sampling requests */
+  maxTokens?: number;
+
+  /** Enable OpenTelemetry tracing */
+  tracingEnabled?: boolean;
+
+  /** Sampling configuration */
+  samplingConfig?: SamplingConfig;
+
+  /** Provider options for AI SDK sampling mode */
+  providerOptions?: {
+    modelPreferences?: {
+      hints?: Array<{ name?: string }>;
+      costPriority?: number;
+      speedPriority?: number;
+      intelligencePriority?: number;
+    };
+  };
+
+  /** ACP settings for AI SDK ACP mode */
+  acpSettings?: {
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    session?: {
+      cwd?: string;
+      mcpServers?: Array<{
+        name: string;
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+      }>;
+    };
+    persistSession?: boolean;
+  };
+
+  /** Tool reference overrides */
+  refs?: Array<ToolRefXml>;
+}
+
+/**
+ * Agent definition - defines an agentic tool with its dependencies.
+ */
+export interface AgentDef {
+  /** Agent name - set to null for composition-only mode (no tool created) */
+  name: string | null;
+
+  /** Agent description with <tool> tags for tool references */
+  description?: string;
+
+  /**
+   * MCP server dependencies - flat structure
+   * @example
+   * ```typescript
+   * mcpServers: {
+   *   "desktop-commander": {
+   *     command: "npx",
+   *     args: ["-y", "@wonderwhy-er/desktop-commander"],
+   *   },
+   * }
+   * ```
+   */
+  mcpServers?: Record<string, McpServerDef>;
+
+  /**
+   * Execution mode for this agent
+   * @default "agentic"
+   */
+  mode?: ExecutionMode;
+
+  /**
+   * Agent-specific plugins (in addition to global plugins).
+   */
+  plugins?: (ToolPlugin | string)[];
+
+  /**
+   * Advanced options for specialized execution modes.
+   * Most users don't need this.
+   */
+  options?: AgentOptions;
+}
+
+/**
+ * Server capabilities configuration
+ */
+export interface ServerCapabilities {
+  tools?: {
+    listChanged?: boolean;
+  };
+  sampling?: Record<string, unknown>;
+  logging?: Record<string, unknown>;
+  prompts?: Record<string, unknown>;
+  resources?: Record<string, unknown>;
+}
+
+/**
+ * Main configuration for mcpc API.
+ * All options in a single, flat configuration object.
+ */
+export interface McpcConfig {
+  // ============ Server Configuration ============
+
+  /** Server name (required) */
+  name: string;
+
+  /**
+   * Server version
+   * @default "1.0.0"
+   */
+  version?: string;
+
+  /**
+   * Server capabilities
+   * @default { tools: { listChanged: true } }
+   */
+  capabilities?: ServerCapabilities;
+
+  // ============ Agent Configuration ============
+
+  /**
+   * Single agent definition (shorthand for `agents: [...]`).
+   * Use this when you only have one agent.
+   *
+   * @example
+   * ```typescript
+   * agent: { name: "file-manager", description: "...", mcpServers: {...} }
+   * ```
+   */
+  agent?: AgentDef | string;
+
+  /**
+   * Multiple agent definitions - can be inline objects or file paths.
+   * File paths require the markdown-loader plugin.
+   *
+   * @example
+   * ```typescript
+   * agents: [
+   *   { name: "file-reader", description: "...", mcpServers: {...} },
+   *   "./agents/coding-agent.md"
+   * ]
+   * ```
+   */
+  agents?: (AgentDef | string)[];
+
+  // ============ Plugin Configuration ============
+
+  /**
+   * Global plugins applied to ALL agents.
+   * Use this for plugins that should affect every agent (e.g., logging, caching).
+   *
+   * For loader plugins (e.g., markdown-loader), use `setup` callback instead.
+   *
+   * @example
+   * ```typescript
+   * plugins: [
+   *   createLargeResultPlugin({ maxSize: 8000 }),
+   *   createLoggingPlugin(),
+   * ]
+   * ```
+   */
+  plugins?: (ToolPlugin | string)[];
+
+  // ============ Setup Hook ============
+
+  /**
+   * Setup callback for custom configuration.
+   * Called after plugins are loaded but before agents are composed.
+   *
+   * @example
+   * ```typescript
+   * setup: async (server) => {
+   *   server.tool("custom-tool", "desc", schema, handler);
+   * }
+   * ```
+   */
+  setup?: (server: ComposableMCPServer) => void | Promise<void>;
+}
+
+/**
+ * Convert AgentDef to legacy ComposeDefinition format
+ * @param agent - The agent definition
+ * @param globalPlugins - Global plugins to merge with agent plugins
+ */
+function agentDefToComposeDefinition(
+  agent: AgentDef,
+  globalPlugins: (ToolPlugin | string)[] = [],
+): import("./set-up-mcp-compose.ts").ComposeDefinition {
+  // Convert flat mcpServers to nested deps.mcpServers structure
+  const deps: MCPSetting | undefined = agent.mcpServers
+    ? {
+      mcpServers: Object.fromEntries(
+        Object.entries(agent.mcpServers).map(([name, def]) => [
+          name,
+          {
+            command: def.command,
+            args: def.args,
+            env: def.env,
+            transportType: def.transportType ??
+              (def.command ? "stdio" : undefined),
+            url: def.url,
+            headers: def.headers,
+          },
+        ]),
+      ) as MCPSetting["mcpServers"],
+    }
+    : undefined;
+
+  // Merge global plugins with agent-specific plugins
+  // Global plugins come first, then agent-specific plugins
+  const mergedPlugins = [...globalPlugins, ...(agent.plugins ?? [])];
+
+  return {
+    name: agent.name,
+    description: agent.description,
+    deps,
+    plugins: mergedPlugins.length > 0 ? mergedPlugins : undefined,
+    options: {
+      mode: agent.mode,
+      // Spread advanced options from agent.options
+      ...agent.options,
+    },
+  };
+}
+
+/**
+ * Global markdown loader reference
+ */
+let markdownAgentLoader: MarkdownAgentLoader | null = null;
+
+/**
+ * Register the Markdown agent loader
+ */
+export function registerMarkdownLoader(loader: MarkdownAgentLoader): void {
+  markdownAgentLoader = loader;
+  _setMarkdownAgentLoader(loader);
+}
+
+/**
+ * Resolve agent input to AgentDef
+ */
+async function resolveAgentInput(input: AgentDef | string): Promise<AgentDef> {
+  if (typeof input !== "string") {
+    return input;
+  }
+
+  if (!isMarkdownFile(input)) {
+    throw new Error(
+      `Invalid agent input: "${input}". ` +
+        `Expected a Markdown file path (.md) or an AgentDef object.`,
+    );
+  }
+
+  if (!markdownAgentLoader) {
+    throw new Error(
+      `Cannot load Markdown agent file "${input}": Markdown loader not available. ` +
+        `Add "@mcpc/plugin-markdown-loader" to plugins, or use inline AgentDef objects.`,
+    );
+  }
+
+  const composeDef = await markdownAgentLoader(input);
+
+  // Convert ComposeDefinition back to AgentDef
+  return {
+    name: composeDef.name,
+    description: composeDef.description,
+    mcpServers: composeDef.deps?.mcpServers
+      ? Object.fromEntries(
+        Object.entries(composeDef.deps.mcpServers).map(([name, def]) => [
+          name,
+          {
+            command: (def as any).command,
+            args: (def as any).args,
+            env: (def as any).env,
+            transportType: (def as any).transportType,
+            url: (def as any).url,
+            headers: (def as any).headers,
+          },
+        ]),
+      )
+      : undefined,
+    mode: composeDef.options?.mode,
+    plugins: composeDef.plugins,
+    // Pack advanced options into options field
+    options: {
+      maxSteps: composeDef.options?.maxSteps,
+      maxTokens: composeDef.options?.maxTokens,
+      tracingEnabled: composeDef.options?.tracingEnabled,
+      samplingConfig: composeDef.options?.samplingConfig,
+      providerOptions: composeDef.options?.providerOptions,
+      acpSettings: composeDef.options?.acpSettings,
+      refs: composeDef.options?.refs,
+    },
+  };
+}
+
+/**
+ * Create and configure an agentic MCP server with composed tools.
+ *
+ * Uses a single configuration object for cleaner usage.
+ *
+ * @example
+ * ```typescript
+ * import { mcpc } from "@mcpc/core";
+ * import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+ *
+ * const server = await mcpc({
+ *   name: "my-server",
+ *   version: "1.0.0",
+ *   capabilities: { tools: { listChanged: true } },
+ *
+ *   agents: [{
+ *     name: "file-manager",
+ *     description: `A file management agent.
+ *       <tool name="desktop-commander.read_file"/>
+ *       <tool name="desktop-commander.write_file"/>`,
+ *     mcpServers: {
+ *       "desktop-commander": {
+ *         command: "npx",
+ *         args: ["-y", "@wonderwhy-er/desktop-commander"],
+ *       },
+ *     },
+ *   }],
+ *
+ *   plugins: ["@mcpc/plugin-markdown-loader"],
+ * });
+ *
+ * await server.connect(new StdioServerTransport());
+ * ```
+ *
+ * @param config - Server and agent configuration
+ * @returns A configured MCP Server instance ready to connect
+ */
+export async function mcpc(
+  config: McpcConfig,
+): Promise<ComposableMCPServer> {
+  const {
+    name,
+    version = "1.0.0",
+    capabilities = { tools: { listChanged: true } },
+    agent,
+    agents = [],
+    plugins = [],
+    setup,
+  } = config;
+
+  // Merge agent (singular) into agents array
+  const allAgents = agent ? [agent, ...agents] : agents;
+
+  // Create server with flattened configuration
+  const server = new ComposableMCPServer(
+    { name, version },
+    { capabilities: { logging: {}, ...capabilities } },
+  );
+
+  // Initialize built-in plugins
+  await server.initBuiltInPlugins();
+
+  // Run setup callback if provided (can be used for loader plugins like markdown-loader)
+  if (setup) {
+    await setup(server);
+  }
+
+  // Resolve all agent inputs (file paths and inline definitions)
+  const resolvedAgents = await Promise.all(allAgents.map(resolveAgentInput));
+
+  // Compose each agent with global plugins merged
+  for (const agent of resolvedAgents) {
+    const composeDef = agentDefToComposeDefinition(agent, plugins);
+
+    // Load plugins for this agent (global + agent-specific)
+    if (composeDef.plugins) {
+      for (const plugin of composeDef.plugins) {
+        if (typeof plugin === "string") {
+          await server.loadPluginFromPath(plugin);
+        } else {
+          await server.addPlugin(plugin);
+        }
+      }
+    }
+
+    await server.compose(
+      composeDef.name,
+      composeDef.description ?? "",
+      composeDef.deps,
+      composeDef.options,
+    );
+  }
+
+  return server;
+}
+
+// ============ Type Exports ============
+
+export type { ToolPlugin } from "./plugin-types.ts";
+export type { ExecutionMode } from "./prompts/types.ts";
+export type { SamplingConfig, ToolRefXml } from "./types.ts";

--- a/packages/core/tests/integration/client_list_tools.ts
+++ b/packages/core/tests/integration/client_list_tools.ts
@@ -3,13 +3,13 @@
  */
 
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { mcpc } from "../../src/set-up-mcp-compose.ts";
+import { mcpc as mcpcLegacy } from "../../src/set-up-mcp-compose.ts";
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { assertArrayIncludes, assertEquals } from "@std/assert";
 import { jsonSchema } from "../../src/utils/schema.ts";
 
 Deno.test("Client list tools - agentic server + public tools", async () => {
-  const server = await mcpc(
+  const server = await mcpcLegacy(
     [{ name: "test-server", version: "1.0.0" }, {}],
     [
       {
@@ -54,7 +54,7 @@ Deno.test("Client list tools - agentic server + public tools", async () => {
 });
 
 Deno.test("Client list tools - agentic server + internal", async () => {
-  const server = await mcpc(
+  const server = await mcpcLegacy(
     [{ name: "test-server", version: "1.0.0" }, {}],
     [
       {
@@ -113,7 +113,7 @@ Deno.test("Client list tools - agentic server + internal", async () => {
 Deno.test(
   "Client list tools - agentic server, jsonSchema compatibility",
   async () => {
-    const server = await mcpc(
+    const server = await mcpcLegacy(
       [{ name: "test-server", version: "1.0.0" }, {}],
       [
         {
@@ -170,7 +170,7 @@ Deno.test(
     sanitizeOps: false,
   },
   async () => {
-    const server = await mcpc(
+    const server = await mcpcLegacy(
       [{ name: "test-server", version: "1.0.0" }, {}],
       [
         {

--- a/packages/core/tests/integration/plugin_lifecycle_test.ts
+++ b/packages/core/tests/integration/plugin_lifecycle_test.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import type { ToolPlugin } from "../../src/plugin-types.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";
 

--- a/packages/core/tests/integration/tool_execution_hooks_test.ts
+++ b/packages/core/tests/integration/tool_execution_hooks_test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assertEquals, assertExists } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import type {
   AfterToolExecuteContext,
   BeforeToolExecuteContext,

--- a/packages/core/tests/plugins/large_result_plugin_path_test.ts
+++ b/packages/core/tests/plugins/large_result_plugin_path_test.ts
@@ -1,4 +1,4 @@
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";
 import type { ComposeDefinition } from "../../src/set-up-mcp-compose.ts";
 import type { ComposableMCPServer } from "../../src/compose.ts";

--- a/packages/core/tests/plugins/large_result_plugin_test.ts
+++ b/packages/core/tests/plugins/large_result_plugin_test.ts
@@ -1,4 +1,4 @@
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";
 import { createLargeResultPlugin } from "../../src/plugins/large-result.ts";
 import type { ComposeDefinition } from "../../src/set-up-mcp-compose.ts";

--- a/packages/core/tests/plugins/runtime_transform_test.ts
+++ b/packages/core/tests/plugins/runtime_transform_test.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import type { ToolPlugin } from "../../src/plugin-types.ts";
 import type { ComposableMCPServer } from "../../src/compose.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";

--- a/packages/core/tests/plugins/skills_plugin_test.ts
+++ b/packages/core/tests/plugins/skills_plugin_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { createSkillsPlugin } from "../../src/plugins/skills.ts";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ComposeDefinition } from "../../src/set-up-mcp-compose.ts";

--- a/packages/core/tests/unit/agentic_executor_test.ts
+++ b/packages/core/tests/unit/agentic_executor_test.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertEquals, assertExists } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 
 Deno.test(
   "Agentic mode - executes tool with tool + args format",

--- a/packages/core/tests/unit/ai-sdk-adapter_test.ts
+++ b/packages/core/tests/unit/ai-sdk-adapter_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertExists } from "@std/assert";
-import { type ComposeDefinition, convertToAISDKTools, mcpc } from "@mcpc/core";
+import {
+  type ComposeDefinition,
+  convertToAISDKTools,
+  mcpcLegacy as mcpc,
+} from "@mcpc/core";
 
 // Mock AI SDK helpers for testing
 const mockTool = (options: {

--- a/packages/core/tests/unit/mcpc_api_test.ts
+++ b/packages/core/tests/unit/mcpc_api_test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the new mcpc API (single configuration object pattern)
+ */
+import { assertEquals, assertExists } from "@std/assert";
+import { type AgentDef, mcpc } from "../../mod.ts";
+
+Deno.test("mcpc API - minimal config with defaults", async () => {
+  const server = await mcpc({
+    name: "test-server",
+  });
+
+  assertExists(server);
+});
+
+Deno.test("mcpc API - single agent with 'agent' field", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agent: {
+      name: "test-agent",
+      description: "A test agent",
+    },
+  });
+
+  assertExists(server);
+  const tools = server.getPublicTools();
+  assertEquals(tools.length, 1);
+  assertEquals(tools[0].name, "test-agent");
+});
+
+Deno.test("mcpc API - multiple agents with 'agents' field", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agents: [
+      { name: "agent-1", description: "First agent" },
+      { name: "agent-2", description: "Second agent" },
+    ],
+  });
+
+  assertExists(server);
+  const tools = server.getPublicTools();
+  assertEquals(tools.length, 2);
+});
+
+Deno.test("mcpc API - agent + agents combined", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agent: { name: "main-agent", description: "Main" },
+    agents: [
+      { name: "helper-1", description: "Helper 1" },
+      { name: "helper-2", description: "Helper 2" },
+    ],
+  });
+
+  assertExists(server);
+  const tools = server.getPublicTools();
+  assertEquals(tools.length, 3);
+  // agent comes first
+  assertEquals(tools[0].name, "main-agent");
+});
+
+Deno.test("mcpc API - composition-only mode (name: null)", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agent: {
+      name: null,
+      description: "Composition only, no tool created",
+    },
+  });
+
+  assertExists(server);
+  const tools = server.getPublicTools();
+  assertEquals(tools.length, 0);
+});
+
+Deno.test("mcpc API - global plugins applied to all agents", async () => {
+  const pluginCalls: string[] = [];
+
+  const server = await mcpc({
+    name: "test-server",
+    plugins: [
+      {
+        name: "test-plugin",
+        beforeToolExecute: (ctx) => {
+          pluginCalls.push(`before:${ctx.toolName}`);
+          return undefined;
+        },
+      },
+    ],
+    agents: [
+      { name: "agent-1", description: "First" },
+      { name: "agent-2", description: "Second" },
+    ],
+  });
+
+  assertExists(server);
+  // Plugin should be registered (actual execution tested elsewhere)
+});
+
+Deno.test("mcpc API - agent with mode", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agent: {
+      name: "agentic-tool",
+      description: "An agentic tool",
+      mode: "agentic",
+    },
+  });
+
+  assertExists(server);
+});
+
+Deno.test("mcpc API - agent with advanced options", async () => {
+  const server = await mcpc({
+    name: "test-server",
+    agent: {
+      name: "sampling-agent",
+      description: "A sampling agent",
+      mode: "ai_sampling",
+      options: {
+        maxSteps: 30,
+        maxTokens: 64000,
+        tracingEnabled: true,
+      },
+    },
+  });
+
+  assertExists(server);
+});
+
+Deno.test("mcpc API - setup callback", async () => {
+  let setupCalled = false;
+
+  const server = await mcpc({
+    name: "test-server",
+    setup: (_s) => {
+      setupCalled = true;
+      // Can add custom tools here
+    },
+  });
+
+  assertExists(server);
+  assertEquals(setupCalled, true);
+});
+
+Deno.test("mcpc API - AgentDef type export works", () => {
+  // Type check - should compile
+  const agent: AgentDef = {
+    name: "typed-agent",
+    description: "A typed agent",
+    mcpServers: {
+      "test-server": {
+        command: "echo",
+        args: ["hello"],
+      },
+    },
+    mode: "agentic",
+    plugins: [],
+    options: {
+      maxSteps: 10,
+    },
+  };
+
+  assertExists(agent);
+  assertEquals(agent.name, "typed-agent");
+});

--- a/packages/core/tests/unit/plugin_manager_test.ts
+++ b/packages/core/tests/unit/plugin_manager_test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assertEquals, assertRejects } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import type { ToolPlugin } from "../../src/plugin-types.ts";
 
 Deno.test("PluginManager - register valid plugin", async () => {

--- a/packages/core/tests/unit/schema_compatibility_test.ts
+++ b/packages/core/tests/unit/schema_compatibility_test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import {
   extractJsonSchema,
   isWrappedSchema,

--- a/packages/core/tests/unit/tool_manager_test.ts
+++ b/packages/core/tests/unit/tool_manager_test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";
 
 Deno.test("ToolManager - register and retrieve tool", async () => {

--- a/packages/core/tests/unit/tool_resolution_test.ts
+++ b/packages/core/tests/unit/tool_resolution_test.ts
@@ -1,4 +1,4 @@
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 import { jsonSchema } from "../../src/utils/schema.ts";
 
 Deno.test("callTool resolves tools from registry (no config)", async () => {

--- a/packages/core/tests/unit/tool_warning_test.ts
+++ b/packages/core/tests/unit/tool_warning_test.ts
@@ -1,4 +1,4 @@
-import { mcpc } from "../../mod.ts";
+import { mcpcLegacy as mcpc } from "../../mod.ts";
 
 Deno.test(
   "Tool warning system - shows warning for non-existent tools",

--- a/packages/mcp-sampling-ai-provider/examples/background_code_analysis.ts
+++ b/packages/mcp-sampling-ai-provider/examples/background_code_analysis.ts
@@ -15,7 +15,7 @@
  * deno run --allow-all examples/background_code_analysis.ts
  */
 
-import { mcpc } from "../../core/mod.ts";
+import { mcpcLegacy as mcpc } from "../../core/mod.ts";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMCPSamplingProvider } from "../mod.ts";
 import { generateText, jsonSchema, stepCountIs, tool } from "ai";

--- a/packages/mcp-sampling-ai-provider/examples/simple_server.ts
+++ b/packages/mcp-sampling-ai-provider/examples/simple_server.ts
@@ -15,7 +15,7 @@
  * 8. Client completes response.
  */
 
-import { mcpc } from "../../core/mod.ts";
+import { mcpcLegacy as mcpc } from "../../core/mod.ts";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { createMCPSamplingProvider } from "../mod.ts";

--- a/packages/mcpc-builder/mcpc-builder-agent.ts
+++ b/packages/mcpc-builder/mcpc-builder-agent.ts
@@ -5,7 +5,7 @@
  * Uses in-memory transport for zero-overhead communication.
  */
 
-import { type ComposeDefinition, mcpc } from "@mcpc/core";
+import { type ComposeDefinition, mcpcLegacy } from "@mcpc/core";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./mod.ts";
 
@@ -48,7 +48,7 @@ I help you discover and compose MCP servers from the mcpc.tech registry to build
 `;
 
 (async () => {
-  const server = await mcpc(
+  const server = await mcpcLegacy(
     [
       { name: "mcpc-builder-agent", version: "1.0.0" },
       { capabilities: { tools: {} } },

--- a/packages/plugin-code-execution/examples/basic-usage.ts
+++ b/packages/plugin-code-execution/examples/basic-usage.ts
@@ -10,7 +10,7 @@
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { type ComposeDefinition, mcpc } from "@mcpc/core";
+import { type ComposeDefinition, mcpcLegacy } from "@mcpc/core";
 import { createCodeExecutionPlugin } from "@mcpc/plugin-code-execution/plugin";
 
 const toolDefinitions: ComposeDefinition[] = [
@@ -48,7 +48,7 @@ The code can call MCP tools via \`callMCPTool(toolName, params)\` function.`,
 ];
 
 // Create server with code execution plugin
-const server = await mcpc(
+const server = await mcpcLegacy(
   [
     {
       name: "sandbox-demo",

--- a/packages/plugin-code-execution/tests/code_execution.test.ts
+++ b/packages/plugin-code-execution/tests/code_execution.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { mcpc } from "@mcpc/core";
+import { mcpcLegacy as mcpc } from "@mcpc/core";
 import { createCodeExecutionPlugin } from "../mod.ts";
 
 Deno.test(


### PR DESCRIPTION
- Add AgentOptions interface for advanced options (maxSteps, maxTokens, tracingEnabled, samplingConfig, providerOptions, acpSettings, refs)
- Simplify AgentDef from 13 fields to 6 fields (name, description, mcpServers, mode, plugins, options)
- Add global plugins support that apply to all agents
- Add default values: version='1.0.0', capabilities={ tools: { listChanged: true } }
- Add 'agent' singular field for simpler single-agent configs
- Add mcpc_api_test.ts with 10 tests covering new API
- Update examples to use new structure