### PR TITLE
feat: add configurable bash plugins

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,9 @@
     "./packages/mcpc-builder",
     "./packages/plugin-code-execution",
     "./packages/plugin-code-execution-sampling",
-    "./packages/plugin-markdown-loader"
+    "./packages/plugin-markdown-loader",
+    "./packages/plugin-bash-just",
+    "./packages/plugin-bash-exec"
   ],
   "imports": {
     "@mcpc/utils": "./packages/utils/mod.ts",
@@ -29,6 +31,8 @@
     "@mcpc/plugin-code-execution/sandbox": "./packages/plugin-code-execution/src/sandbox-executor.ts",
     "@mcpc/plugin-code-execution-sampling": "./packages/plugin-code-execution-sampling/mod.ts",
     "@mcpc/plugin-markdown-loader": "./packages/plugin-markdown-loader/mod.ts",
+    "@mcpc/plugin-bash-just": "./packages/plugin-bash-just/mod.ts",
+    "@mcpc/plugin-bash-exec": "./packages/plugin-bash-exec/mod.ts",
     "@es-toolkit/es-toolkit": "jsr:@es-toolkit/es-toolkit@^1.37.2",
     "json-schema-faker": "npm:json-schema-faker@^0.5.9",
     "json-schema-traverse": "npm:json-schema-traverse@^1.0.0",

--- a/deno.lock
+++ b/deno.lock
@@ -46,7 +46,9 @@
     "npm:json-schema-faker@~0.5.9": "0.5.9",
     "npm:json-schema-traverse@1": "1.0.0",
     "npm:jsonrepair@^3.13.0": "3.13.2",
+    "npm:just-bash@^3.0.1": "3.0.1",
     "npm:minimist@^1.2.8": "1.2.8",
+    "npm:secure-exec@~0.2.1": "0.2.1",
     "npm:zod@^3.23.8": "3.25.76",
     "npm:zod@^3.24.2": "3.25.76"
   },
@@ -215,6 +217,39 @@
         "zod"
       ]
     },
+    "@borewit/text-codec@0.2.2": {
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="
+    },
+    "@cbor-extract/cbor-extract-darwin-arm64@2.2.2": {
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@cbor-extract/cbor-extract-darwin-x64@2.2.2": {
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@cbor-extract/cbor-extract-linux-arm64@2.2.2": {
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@cbor-extract/cbor-extract-linux-arm@2.2.2": {
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@cbor-extract/cbor-extract-linux-x64@2.2.2": {
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@cbor-extract/cbor-extract-win32-x64@2.2.2": {
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@deno/darwin-arm64@2.6.5": {
       "integrity": "sha512-jHO9d9XsB2YzVUsJr7U9DEj7QEw69yMYbyaLbK1bpHJ6IjYRJFU/Wi7I1b9jSXurezQQulKf75+9QbU27XkL2g==",
       "os": ["darwin"],
@@ -264,6 +299,136 @@
         "tslib"
       ]
     },
+    "@esbuild/aix-ppc64@0.27.7": {
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.27.7": {
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.27.7": {
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.27.7": {
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.27.7": {
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.27.7": {
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.27.7": {
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.27.7": {
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.27.7": {
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.27.7": {
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.27.7": {
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.27.7": {
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.27.7": {
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.27.7": {
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.27.7": {
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.27.7": {
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.27.7": {
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.27.7": {
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.27.7": {
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.27.7": {
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.27.7": {
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.27.7": {
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/sunos-x64@0.27.7": {
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.27.7": {
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.27.7": {
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.27.7": {
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@hono/node-server@1.19.9_hono@4.11.5": {
       "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
       "dependencies": [
@@ -285,6 +450,33 @@
       "dependencies": [
         "hono",
         "zod"
+      ]
+    },
+    "@jitl/quickjs-ffi-types@0.32.0": {
+      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="
+    },
+    "@jitl/quickjs-wasmfile-debug-asyncify@0.32.0": {
+      "integrity": "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
+    "@jitl/quickjs-wasmfile-debug-sync@0.32.0": {
+      "integrity": "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
+    "@jitl/quickjs-wasmfile-release-asyncify@0.32.0": {
+      "integrity": "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
+    "@jitl/quickjs-wasmfile-release-sync@0.32.0": {
+      "integrity": "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
       ]
     },
     "@jsep-plugin/assignment@1.3.0_jsep@1.4.0": {
@@ -406,6 +598,9 @@
         "@mcpc-tech/ripgrep-napi-win32-x64-msvc"
       ]
     },
+    "@mixmark-io/domino@2.2.0": {
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
     "@modelcontextprotocol/sdk@1.25.3_zod@3.25.76_hono@4.11.5_ajv@8.17.1_express@5.2.1": {
       "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
       "dependencies": [
@@ -427,6 +622,14 @@
         "zod-to-json-schema"
       ]
     },
+    "@mongodb-js/zstd@7.0.0": {
+      "integrity": "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==",
+      "dependencies": [
+        "node-addon-api",
+        "prebuild-install"
+      ],
+      "scripts": true
+    },
     "@napi-rs/wasm-runtime@1.1.1": {
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dependencies": [
@@ -434,6 +637,9 @@
         "@emnapi/runtime",
         "@tybys/wasm-util"
       ]
+    },
+    "@nodable/entities@2.1.0": {
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="
     },
     "@opentelemetry/api-logs@0.56.0": {
       "integrity": "sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==",
@@ -613,6 +819,57 @@
     "@protobufjs/utf8@1.1.0": {
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@secure-exec/core@0.2.1": {
+      "integrity": "sha512-HsnUv6gClpMA1BBRmX86j30TKTZtgJC/fO1tVavr7IpM2zNKbHU8LgSlBd7mv2SNy02ImTmU/GnQ3aYB4NSbEg==",
+      "dependencies": [
+        "better-sqlite3"
+      ]
+    },
+    "@secure-exec/nodejs@0.2.1": {
+      "integrity": "sha512-UJMJqVFxexlHJV0Q9nWURvrz6GElj8673DDOOFln6FHR6JS+9SaSU3eISrN158DuNC3SFi4rgjb/scKnK4YOYQ==",
+      "dependencies": [
+        "@secure-exec/core",
+        "@secure-exec/v8",
+        "cbor-x",
+        "cjs-module-lexer",
+        "es-module-lexer",
+        "esbuild",
+        "node-stdlib-browser",
+        "web-streams-polyfill"
+      ]
+    },
+    "@secure-exec/v8-darwin-arm64@0.2.1": {
+      "integrity": "sha512-gEWhMHzUpLwzuBNAD0lVkZXE8wFlWMLp4IOZ+56FYwOW/C+m07cYxuW4TjHyPqZ+vPm3IkoaMqqH5yT9VhjX/Q==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@secure-exec/v8-darwin-x64@0.2.1": {
+      "integrity": "sha512-H2Z5K+Cq+fn/kxjGvhJzepnNFWG6qNdyhZybVWGr5bAAZoSz/Qkad4WnXcurWU+880tKDtnf19LHBXrg7zewNQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@secure-exec/v8-linux-arm64-gnu@0.2.1": {
+      "integrity": "sha512-14subGhVV/gW35mYYm7Gv1Keeex7PxIgQfoKji/JH7wYyDuarP6kgaES0nJw+JXVkxEVud52c+kbcIjIggqCEw==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@secure-exec/v8-linux-x64-gnu@0.2.1": {
+      "integrity": "sha512-Az4s+vUf+78vWtsC7rTn/jQc6WKJafAdt2YpEjB4Gnu+sX+FFTIst1hRV4gJonbRyJdy6SW+OQ6DZatmwczorQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@secure-exec/v8@0.2.1": {
+      "integrity": "sha512-ye/seCqzvyMGnvyP+AO7RkVMR/lE3x9m0D2PfmiAXA457R78ZmOFmZ6v+JlJG2vv3LM30KsSXTUhwpG+Teh0hw==",
+      "dependencies": [
+        "cbor-x"
+      ],
+      "optionalDependencies": [
+        "@secure-exec/v8-darwin-arm64",
+        "@secure-exec/v8-darwin-x64",
+        "@secure-exec/v8-linux-arm64-gnu",
+        "@secure-exec/v8-linux-x64-gnu"
+      ]
+    },
     "@segment/ajv-human-errors@2.15.0_ajv@8.17.1": {
       "integrity": "sha512-tgeMMuYYJt3Aar5IIk3kyfL9zMvGsv5d7KsVT/2auri+hEH/L2M1i8X67ne4JjMWZqENYIGY1WuI4oPEL1H/xA==",
       "dependencies": [
@@ -621,6 +878,16 @@
     },
     "@standard-schema/spec@1.1.0": {
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@tokenizer/inflate@0.4.1": {
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dependencies": [
+        "debug",
+        "token-types"
+      ]
+    },
+    "@tokenizer/token@0.3.0": {
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@tybys/wasm-util@0.10.1": {
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
@@ -691,8 +958,66 @@
     "argparse@1.0.10": {
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": [
-        "sprintf-js"
+        "sprintf-js@1.0.3"
       ]
+    },
+    "asn1.js@4.10.1": {
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "inherits",
+        "minimalistic-assert"
+      ]
+    },
+    "assert@2.1.0": {
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dependencies": [
+        "call-bind",
+        "is-nan",
+        "object-is",
+        "object.assign",
+        "util"
+      ]
+    },
+    "available-typed-arrays@1.0.7": {
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": [
+        "possible-typed-array-names"
+      ]
+    },
+    "balanced-match@4.0.4": {
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "better-sqlite3@12.10.0": {
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "dependencies": [
+        "bindings",
+        "prebuild-install"
+      ],
+      "scripts": true
+    },
+    "bindings@1.5.0": {
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": [
+        "file-uri-to-path"
+      ]
+    },
+    "bl@4.1.0": {
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": [
+        "buffer",
+        "inherits",
+        "readable-stream@3.6.2"
+      ]
+    },
+    "bn.js@4.12.3": {
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+    },
+    "bn.js@5.2.3": {
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
     },
     "body-parser@2.2.2": {
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
@@ -711,6 +1036,90 @@
     "boolbase@1.0.0": {
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
+    "brace-expansion@5.0.6": {
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dependencies": [
+        "balanced-match"
+      ]
+    },
+    "brorand@1.1.0": {
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "browser-resolve@2.0.0": {
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dependencies": [
+        "resolve"
+      ]
+    },
+    "browserify-aes@1.2.0": {
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dependencies": [
+        "buffer-xor",
+        "cipher-base",
+        "create-hash",
+        "evp_bytestokey",
+        "inherits",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "browserify-cipher@1.0.1": {
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dependencies": [
+        "browserify-aes",
+        "browserify-des",
+        "evp_bytestokey"
+      ]
+    },
+    "browserify-des@1.0.2": {
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dependencies": [
+        "cipher-base",
+        "des.js",
+        "inherits",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "browserify-rsa@4.1.1": {
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dependencies": [
+        "bn.js@5.2.3",
+        "randombytes",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "browserify-sign@4.2.5": {
+      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "dependencies": [
+        "bn.js@5.2.3",
+        "browserify-rsa",
+        "create-hash",
+        "create-hmac",
+        "elliptic",
+        "inherits",
+        "parse-asn1",
+        "readable-stream@2.3.8",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "browserify-zlib@0.2.0": {
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dependencies": [
+        "pako"
+      ]
+    },
+    "buffer-xor@1.0.3": {
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+    },
+    "buffer@5.7.1": {
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
+      ]
+    },
+    "builtin-status-codes@3.0.0": {
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+    },
     "bytes@3.1.2": {
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
@@ -719,6 +1128,15 @@
       "dependencies": [
         "es-errors",
         "function-bind"
+      ]
+    },
+    "call-bind@1.0.9": {
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "get-intrinsic",
+        "set-function-length"
       ]
     },
     "call-bound@1.0.4": {
@@ -730,6 +1148,28 @@
     },
     "call-me-maybe@1.0.2": {
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
+    "cbor-extract@2.2.2": {
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "dependencies": [
+        "node-gyp-build-optional-packages"
+      ],
+      "optionalDependencies": [
+        "@cbor-extract/cbor-extract-darwin-arm64",
+        "@cbor-extract/cbor-extract-darwin-x64",
+        "@cbor-extract/cbor-extract-linux-arm",
+        "@cbor-extract/cbor-extract-linux-arm64",
+        "@cbor-extract/cbor-extract-linux-x64",
+        "@cbor-extract/cbor-extract-win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "cbor-x@1.6.4": {
+      "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
+      "optionalDependencies": [
+        "cbor-extract"
+      ]
     },
     "cheerio-select@2.1.0": {
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
@@ -758,6 +1198,29 @@
         "whatwg-mimetype"
       ]
     },
+    "chownr@1.1.4": {
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "cipher-base@1.0.7": {
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dependencies": [
+        "inherits",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ]
+    },
+    "cjs-module-lexer@2.2.0": {
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="
+    },
+    "commander@6.2.1": {
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+    },
+    "console-browserify@1.2.0": {
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+    },
+    "constants-browserify@1.0.0": {
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="
+    },
     "content-disposition@1.0.1": {
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="
     },
@@ -770,6 +1233,9 @@
     "cookie@0.7.2": {
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
+    "core-util-is@1.0.3": {
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "cors@2.8.5": {
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dependencies": [
@@ -777,12 +1243,60 @@
         "vary"
       ]
     },
+    "create-ecdh@4.0.4": {
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "elliptic"
+      ]
+    },
+    "create-hash@1.2.0": {
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dependencies": [
+        "cipher-base",
+        "inherits",
+        "md5.js",
+        "ripemd160",
+        "sha.js"
+      ]
+    },
+    "create-hmac@1.1.7": {
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dependencies": [
+        "cipher-base",
+        "create-hash",
+        "inherits",
+        "ripemd160",
+        "safe-buffer@5.2.1",
+        "sha.js"
+      ]
+    },
+    "create-require@1.1.1": {
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": [
         "path-key",
         "shebang-command",
         "which"
+      ]
+    },
+    "crypto-browserify@3.12.1": {
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dependencies": [
+        "browserify-cipher",
+        "browserify-sign",
+        "create-ecdh",
+        "create-hash",
+        "create-hmac",
+        "diffie-hellman",
+        "hash-base@3.0.5",
+        "inherits",
+        "pbkdf2",
+        "public-encrypt",
+        "randombytes",
+        "randomfill"
       ]
     },
     "css-select@5.2.2": {
@@ -804,6 +1318,31 @@
         "ms"
       ]
     },
+    "decompress-response@6.0.0": {
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": [
+        "mimic-response"
+      ]
+    },
+    "deep-extend@0.6.0": {
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "define-data-property@1.1.4": {
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": [
+        "es-define-property",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "define-properties@1.2.1": {
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": [
+        "define-data-property",
+        "has-property-descriptors",
+        "object-keys"
+      ]
+    },
     "deno@2.6.5": {
       "integrity": "sha512-zAEGhAKPyKTA7HwtSVPAmdpj+WQfvw0tPemgkaRsqGLe7oi85iqUPCoCEkItiYp3ZellfQIbDHqQmKUY6fgxig==",
       "optionalDependencies": [
@@ -820,6 +1359,27 @@
     "depd@2.0.0": {
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
+    "des.js@1.1.0": {
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dependencies": [
+        "inherits",
+        "minimalistic-assert"
+      ]
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+    },
+    "diff@8.0.4": {
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="
+    },
+    "diffie-hellman@5.0.3": {
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "miller-rabin",
+        "randombytes"
+      ]
+    },
     "dom-serializer@2.0.0": {
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": [
@@ -827,6 +1387,9 @@
         "domhandler",
         "entities@4.5.0"
       ]
+    },
+    "domain-browser@4.22.0": {
+      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw=="
     },
     "domelementtype@2.3.0": {
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
@@ -856,6 +1419,18 @@
     "ee-first@1.1.1": {
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "elliptic@6.6.1": {
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "brorand",
+        "hash.js",
+        "hmac-drbg",
+        "inherits",
+        "minimalistic-assert",
+        "minimalistic-crypto-utils"
+      ]
+    },
     "encodeurl@2.0.0": {
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
@@ -864,6 +1439,12 @@
       "dependencies": [
         "iconv-lite@0.6.3",
         "whatwg-encoding"
+      ]
+    },
+    "end-of-stream@1.4.5": {
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": [
+        "once"
       ]
     },
     "entities@4.5.0": {
@@ -881,11 +1462,47 @@
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
+    "es-module-lexer@1.7.0": {
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+    },
     "es-object-atoms@1.1.1": {
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": [
         "es-errors"
       ]
+    },
+    "esbuild@0.27.7": {
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/openharmony-arm64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
     },
     "escape-html@1.0.3": {
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
@@ -897,6 +1514,9 @@
     "etag@1.8.1": {
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "eventsource-parser@3.0.6": {
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="
     },
@@ -905,6 +1525,16 @@
       "dependencies": [
         "eventsource-parser"
       ]
+    },
+    "evp_bytestokey@1.0.3": {
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dependencies": [
+        "md5.js",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "expand-template@2.0.3": {
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "express-rate-limit@7.5.1_express@5.2.1": {
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
@@ -951,6 +1581,36 @@
     "fast-uri@3.1.0": {
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
+    "fast-xml-builder@1.2.0": {
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dependencies": [
+        "path-expression-matcher",
+        "xml-naming"
+      ]
+    },
+    "fast-xml-parser@5.8.0": {
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dependencies": [
+        "@nodable/entities",
+        "fast-xml-builder",
+        "path-expression-matcher",
+        "strnum",
+        "xml-naming"
+      ],
+      "bin": true
+    },
+    "file-type@21.3.4": {
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "dependencies": [
+        "@tokenizer/inflate",
+        "strtok3",
+        "token-types",
+        "uint8array-extras"
+      ]
+    },
+    "file-uri-to-path@1.0.0": {
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "finalhandler@2.1.1": {
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "dependencies": [
@@ -962,6 +1622,19 @@
         "statuses"
       ]
     },
+    "find-up@5.0.0": {
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": [
+        "locate-path",
+        "path-exists"
+      ]
+    },
+    "for-each@0.3.5": {
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": [
+        "is-callable"
+      ]
+    },
     "format-util@1.0.5": {
       "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
@@ -971,8 +1644,14 @@
     "fresh@2.0.0": {
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
     },
+    "fs-constants@1.0.0": {
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "generator-function@2.0.1": {
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
     },
     "get-intrinsic@1.3.0": {
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
@@ -996,16 +1675,62 @@
         "es-object-atoms"
       ]
     },
+    "github-from-package@0.0.0": {
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+    },
     "gopd@1.2.0": {
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-property-descriptors@1.0.2": {
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": [
+        "es-define-property"
+      ]
     },
     "has-symbols@1.1.0": {
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
-    "hasown@2.0.2": {
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hash-base@3.0.5": {
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dependencies": [
+        "inherits",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "hash-base@3.1.2": {
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dependencies": [
+        "inherits",
+        "readable-stream@2.3.8",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ]
+    },
+    "hash.js@1.1.7": {
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": [
+        "inherits",
+        "minimalistic-assert"
+      ]
+    },
+    "hasown@2.0.3": {
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dependencies": [
         "function-bind"
+      ]
+    },
+    "hmac-drbg@1.0.1": {
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dependencies": [
+        "hash.js",
+        "minimalistic-assert",
+        "minimalistic-crypto-utils"
       ]
     },
     "hono@4.11.5": {
@@ -1030,6 +1755,9 @@
         "toidentifier"
       ]
     },
+    "https-browserify@1.0.0": {
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
+    },
     "iconv-lite@0.6.3": {
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": [
@@ -1042,17 +1770,83 @@
         "safer-buffer"
       ]
     },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini@1.3.8": {
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "ini@6.0.0": {
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="
     },
     "ipaddr.js@1.9.1": {
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-arguments@1.2.0": {
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": [
+        "call-bound",
+        "has-tostringtag"
+      ]
+    },
+    "is-callable@1.2.7": {
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+    },
+    "is-core-module@2.16.2": {
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dependencies": [
+        "hasown"
+      ]
+    },
+    "is-generator-function@1.1.2": {
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": [
+        "call-bound",
+        "generator-function",
+        "get-proto",
+        "has-tostringtag",
+        "safe-regex-test"
+      ]
+    },
+    "is-nan@1.3.2": {
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": [
+        "call-bind",
+        "define-properties"
+      ]
+    },
     "is-promise@4.0.0": {
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "is-regex@1.2.1": {
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": [
+        "call-bound",
+        "gopd",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "is-typed-array@1.1.15": {
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": [
+        "which-typed-array"
+      ]
+    },
+    "isarray@1.0.0": {
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "isarray@2.0.5": {
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "isomorphic-timers-promises@1.0.1": {
+      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ=="
     },
     "jose@6.1.3": {
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="
@@ -1107,17 +1901,64 @@
       "integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
       "bin": true
     },
+    "just-bash@3.0.1": {
+      "integrity": "sha512-YVyzCN08fKarUnwqy7rKOAcX+2MLYLnYInuowmUXn3mqhrtd4ieZNBuzdQG+qYV9DqnIWuv9Whiph0WRIWsBtw==",
+      "dependencies": [
+        "diff",
+        "fast-xml-parser",
+        "file-type",
+        "ini@6.0.0",
+        "minimatch",
+        "modern-tar",
+        "papaparse",
+        "quickjs-emscripten",
+        "re2js",
+        "seek-bzip",
+        "smol-toml",
+        "sprintf-js@1.1.3",
+        "sql.js",
+        "turndown",
+        "yaml"
+      ],
+      "optionalDependencies": [
+        "@mongodb-js/zstd",
+        "node-liblzma"
+      ],
+      "bin": true
+    },
+    "locate-path@6.0.0": {
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": [
+        "p-locate"
+      ]
+    },
     "long@5.3.2": {
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
+    "md5.js@1.3.5": {
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dependencies": [
+        "hash-base@3.1.2",
+        "inherits",
+        "safe-buffer@5.2.1"
+      ]
+    },
     "media-typer@1.1.0": {
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
     },
     "merge-descriptors@2.0.0": {
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "miller-rabin@4.0.1": {
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "brorand"
+      ],
+      "bin": true
     },
     "mime-db@1.54.0": {
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
@@ -1128,8 +1969,29 @@
         "mime-db"
       ]
     },
+    "mimic-response@3.1.0": {
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+    },
+    "minimalistic-assert@1.0.1": {
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils@1.0.1": {
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+    },
+    "minimatch@10.2.5": {
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dependencies": [
+        "brace-expansion"
+      ]
+    },
     "minimist@1.2.8": {
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "mkdirp-classic@0.5.3": {
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "modern-tar@0.7.6": {
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
@@ -1138,8 +2000,72 @@
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "bin": true
     },
+    "napi-build-utils@2.0.0": {
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "negotiator@1.0.0": {
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "node-abi@3.92.0": {
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dependencies": [
+        "semver"
+      ]
+    },
+    "node-addon-api@8.7.0": {
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="
+    },
+    "node-gyp-build-optional-packages@5.1.1": {
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "dependencies": [
+        "detect-libc"
+      ],
+      "bin": true
+    },
+    "node-gyp-build@4.8.4": {
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": true
+    },
+    "node-liblzma@2.2.0": {
+      "integrity": "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==",
+      "dependencies": [
+        "node-addon-api",
+        "node-gyp-build"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "node-stdlib-browser@1.3.1": {
+      "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
+      "dependencies": [
+        "assert",
+        "browser-resolve",
+        "browserify-zlib",
+        "buffer",
+        "console-browserify",
+        "constants-browserify",
+        "create-require",
+        "crypto-browserify",
+        "domain-browser",
+        "events",
+        "https-browserify",
+        "isomorphic-timers-promises",
+        "os-browserify",
+        "path-browserify",
+        "pkg-dir",
+        "process",
+        "punycode",
+        "querystring-es3",
+        "readable-stream@3.6.2",
+        "stream-browserify",
+        "stream-http",
+        "string_decoder",
+        "timers-browserify",
+        "tty-browserify",
+        "url",
+        "util",
+        "vm-browserify"
+      ]
     },
     "nth-check@2.1.1": {
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
@@ -1152,6 +2078,27 @@
     },
     "object-inspect@1.13.4": {
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "object-is@1.1.6": {
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dependencies": [
+        "call-bind",
+        "define-properties"
+      ]
+    },
+    "object-keys@1.1.1": {
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign@4.1.7": {
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dependencies": [
+        "call-bind",
+        "call-bound",
+        "define-properties",
+        "es-object-atoms",
+        "has-symbols",
+        "object-keys"
+      ]
     },
     "on-finished@2.4.1": {
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
@@ -1177,6 +2124,37 @@
         "yaml"
       ]
     },
+    "os-browserify@0.3.0": {
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="
+    },
+    "p-limit@3.1.0": {
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": [
+        "yocto-queue"
+      ]
+    },
+    "p-locate@5.0.0": {
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": [
+        "p-limit"
+      ]
+    },
+    "pako@1.0.11": {
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "papaparse@5.5.3": {
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
+    },
+    "parse-asn1@5.1.9": {
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dependencies": [
+        "asn1.js",
+        "browserify-aes",
+        "evp_bytestokey",
+        "pbkdf2",
+        "safe-buffer@5.2.1"
+      ]
+    },
     "parse5-htmlparser2-tree-adapter@7.1.0": {
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "dependencies": [
@@ -1199,14 +2177,71 @@
     "parseurl@1.3.3": {
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-browserify@1.0.1": {
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "path-exists@4.0.0": {
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
+    "path-expression-matcher@1.5.0": {
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="
+    },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-parse@1.0.7": {
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp@8.3.0": {
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
     },
+    "pbkdf2@3.1.5": {
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "dependencies": [
+        "create-hash",
+        "create-hmac",
+        "ripemd160",
+        "safe-buffer@5.2.1",
+        "sha.js",
+        "to-buffer"
+      ]
+    },
     "pkce-challenge@5.0.1": {
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "pkg-dir@5.0.0": {
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dependencies": [
+        "find-up"
+      ]
+    },
+    "possible-typed-array-names@1.1.0": {
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
+    "prebuild-install@7.1.3": {
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dependencies": [
+        "detect-libc",
+        "expand-template",
+        "github-from-package",
+        "minimist",
+        "mkdirp-classic",
+        "napi-build-utils",
+        "node-abi",
+        "pump",
+        "rc",
+        "simple-get",
+        "tar-fs",
+        "tunnel-agent"
+      ],
+      "deprecated": true,
+      "bin": true
+    },
+    "process-nextick-args@2.0.1": {
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "process@0.11.10": {
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "protobufjs@7.5.4": {
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
@@ -1233,10 +2268,63 @@
         "ipaddr.js"
       ]
     },
+    "public-encrypt@4.0.3": {
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dependencies": [
+        "bn.js@4.12.3",
+        "browserify-rsa",
+        "create-hash",
+        "parse-asn1",
+        "randombytes",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "pump@3.0.4": {
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dependencies": [
+        "end-of-stream",
+        "once"
+      ]
+    },
+    "punycode@1.4.1": {
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
     "qs@6.14.1": {
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dependencies": [
         "side-channel"
+      ]
+    },
+    "querystring-es3@0.2.1": {
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
+    },
+    "quickjs-emscripten-core@0.32.0": {
+      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
+    "quickjs-emscripten@0.32.0": {
+      "integrity": "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==",
+      "dependencies": [
+        "@jitl/quickjs-wasmfile-debug-asyncify",
+        "@jitl/quickjs-wasmfile-debug-sync",
+        "@jitl/quickjs-wasmfile-release-asyncify",
+        "@jitl/quickjs-wasmfile-release-sync",
+        "quickjs-emscripten-core"
+      ]
+    },
+    "randombytes@2.1.0": {
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": [
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "randomfill@1.0.4": {
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dependencies": [
+        "randombytes",
+        "safe-buffer@5.2.1"
       ]
     },
     "range-parser@1.2.1": {
@@ -1251,8 +2339,59 @@
         "unpipe"
       ]
     },
+    "rc@1.2.8": {
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": [
+        "deep-extend",
+        "ini@1.3.8",
+        "minimist",
+        "strip-json-comments"
+      ],
+      "bin": true
+    },
+    "re2js@1.4.0": {
+      "integrity": "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g==",
+      "deprecated": true
+    },
+    "readable-stream@2.3.8": {
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": [
+        "core-util-is",
+        "inherits",
+        "isarray@1.0.0",
+        "process-nextick-args",
+        "safe-buffer@5.1.2",
+        "string_decoder",
+        "util-deprecate"
+      ]
+    },
+    "readable-stream@3.6.2": {
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": [
+        "inherits",
+        "string_decoder",
+        "util-deprecate"
+      ]
+    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "resolve@1.22.12": {
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dependencies": [
+        "es-errors",
+        "is-core-module",
+        "path-parse",
+        "supports-preserve-symlinks-flag"
+      ],
+      "bin": true
+    },
+    "ripemd160@2.0.3": {
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dependencies": [
+        "hash-base@3.1.2",
+        "inherits"
+      ]
     },
     "router@2.2.0": {
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
@@ -1264,11 +2403,39 @@
         "path-to-regexp"
       ]
     },
+    "safe-buffer@5.1.2": {
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test@1.1.0": {
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-regex"
+      ]
+    },
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "secure-exec@0.2.1": {
+      "integrity": "sha512-oaQDzTPDSCOckYC8G0PimIqzEVxY6sYEvcx0fMGsRR/Wl4wkFVHaZgQ3kc2DHWysV6WHWt5g1AXc/6seafO2XQ==",
+      "dependencies": [
+        "@secure-exec/core",
+        "@secure-exec/nodejs"
+      ]
+    },
     "secure-json-parse@2.7.0": {
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+    },
+    "seek-bzip@2.0.0": {
+      "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+      "dependencies": [
+        "commander"
+      ],
+      "bin": true
     },
     "semver@7.7.3": {
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
@@ -1299,8 +2466,31 @@
         "send"
       ]
     },
+    "set-function-length@1.2.2": {
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": [
+        "define-data-property",
+        "es-errors",
+        "function-bind",
+        "get-intrinsic",
+        "gopd",
+        "has-property-descriptors"
+      ]
+    },
+    "setimmediate@1.0.5": {
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "setprototypeof@1.2.0": {
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "sha.js@2.4.12": {
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dependencies": [
+        "inherits",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ],
+      "bin": true
     },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -1347,17 +2537,130 @@
         "side-channel-weakmap"
       ]
     },
+    "simple-concat@1.0.1": {
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get@4.0.1": {
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dependencies": [
+        "decompress-response",
+        "once",
+        "simple-concat"
+      ]
+    },
+    "smol-toml@1.6.1": {
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="
+    },
     "sprintf-js@1.0.3": {
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "sprintf-js@1.1.3": {
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "sql.js@1.14.1": {
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="
     },
     "statuses@2.0.2": {
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
+    "stream-browserify@3.0.0": {
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": [
+        "inherits",
+        "readable-stream@3.6.2"
+      ]
+    },
+    "stream-http@3.2.0": {
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dependencies": [
+        "builtin-status-codes",
+        "inherits",
+        "readable-stream@3.6.2",
+        "xtend"
+      ]
+    },
+    "string_decoder@1.1.1": {
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": [
+        "safe-buffer@5.1.2"
+      ]
+    },
+    "strip-json-comments@2.0.1": {
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+    },
+    "strnum@2.3.0": {
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="
+    },
+    "strtok3@10.3.5": {
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "dependencies": [
+        "@tokenizer/token"
+      ]
+    },
+    "supports-preserve-symlinks-flag@1.0.0": {
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "tar-fs@2.1.4": {
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dependencies": [
+        "chownr",
+        "mkdirp-classic",
+        "pump",
+        "tar-stream"
+      ]
+    },
+    "tar-stream@2.2.0": {
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": [
+        "bl",
+        "end-of-stream",
+        "fs-constants",
+        "inherits",
+        "readable-stream@3.6.2"
+      ]
+    },
+    "timers-browserify@2.0.12": {
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+      "dependencies": [
+        "setimmediate"
+      ]
+    },
+    "to-buffer@1.2.2": {
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dependencies": [
+        "isarray@2.0.5",
+        "safe-buffer@5.2.1",
+        "typed-array-buffer"
+      ]
+    },
     "toidentifier@1.0.1": {
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "token-types@6.1.2": {
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "dependencies": [
+        "@borewit/text-codec",
+        "@tokenizer/token",
+        "ieee754"
+      ]
+    },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tty-browserify@0.0.1": {
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+    },
+    "tunnel-agent@0.6.0": {
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": [
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "turndown@7.2.4": {
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "dependencies": [
+        "@mixmark-io/domino"
+      ]
     },
     "type-is@2.0.1": {
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
@@ -1366,6 +2669,17 @@
         "media-typer",
         "mime-types"
       ]
+    },
+    "typed-array-buffer@1.0.3": {
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-typed-array"
+      ]
+    },
+    "uint8array-extras@1.5.0": {
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
     },
     "undici-types@7.16.0": {
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
@@ -1376,8 +2690,34 @@
     "unpipe@1.0.0": {
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
+    "url@0.11.4": {
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dependencies": [
+        "punycode",
+        "qs"
+      ]
+    },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "util@0.12.5": {
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": [
+        "inherits",
+        "is-arguments",
+        "is-generator-function",
+        "is-typed-array",
+        "which-typed-array"
+      ]
+    },
     "vary@1.1.2": {
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "vm-browserify@1.1.2": {
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "web-streams-polyfill@4.3.0": {
+      "integrity": "sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw=="
     },
     "whatwg-encoding@3.1.1": {
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
@@ -1389,6 +2729,18 @@
     "whatwg-mimetype@4.0.0": {
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
     },
+    "which-typed-array@1.1.20": {
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dependencies": [
+        "available-typed-arrays",
+        "call-bind",
+        "call-bound",
+        "for-each",
+        "get-proto",
+        "gopd",
+        "has-tostringtag"
+      ]
+    },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
@@ -1399,9 +2751,18 @@
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "xml-naming@0.1.0": {
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="
+    },
+    "xtend@4.0.2": {
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
     "yaml@2.8.2": {
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "bin": true
+    },
+    "yocto-queue@0.1.0": {
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zod-to-json-schema@3.25.1_zod@3.25.76": {
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
@@ -1492,6 +2853,22 @@
           "jsr:@std/assert@^1.0.14",
           "npm:@modelcontextprotocol/sdk@^1.8.0",
           "npm:zod@^3.24.2"
+        ]
+      },
+      "packages/plugin-bash-exec": {
+        "dependencies": [
+          "jsr:@mcpc/core@~0.3.45",
+          "jsr:@std/assert@1",
+          "npm:@modelcontextprotocol/sdk@^1.8.0",
+          "npm:secure-exec@~0.2.1"
+        ]
+      },
+      "packages/plugin-bash-just": {
+        "dependencies": [
+          "jsr:@mcpc/core@~0.3.45",
+          "jsr:@std/assert@1",
+          "npm:@modelcontextprotocol/sdk@^1.8.0",
+          "npm:just-bash@^3.0.1"
         ]
       },
       "packages/plugin-code-execution": {

--- a/packages/core/src/plugins/bash.ts
+++ b/packages/core/src/plugins/bash.ts
@@ -25,6 +25,28 @@ export interface BashPluginOptions {
   maxLines?: number;
   /** Command execution timeout in ms */
   timeoutMs?: number;
+  /**
+   * Custom sandbox function. When provided, replaces the default
+   * `bash -c <command>` execution entirely.
+   *
+   * The plugin still handles output truncation and isError.
+   *
+   * @example
+   * // Delegate to an external service
+   * sandbox: async (command, { cwd, signal }) => {
+   *   const resp = await fetch("https://example.com/run", {
+   *     method: "POST",
+   *     body: JSON.stringify({ command, cwd }),
+   *     signal,
+   *   });
+   *   const data = await resp.json();
+   *   return { stdout: data.stdout, stderr: data.stderr, exitCode: data.exitCode };
+   * }
+   */
+  sandbox?: (
+    command: string,
+    options: { cwd: string; signal: AbortSignal },
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number | null }>;
 }
 
 /**
@@ -75,6 +97,7 @@ export function executeBash(
   return new Promise((resolve) => {
     const stdout: string[] = [];
     const stderr: string[] = [];
+    let resolved = false;
 
     // Use -c to run command string
     const proc = spawn("bash", ["-c", command], {
@@ -90,7 +113,21 @@ export function executeBash(
       stderr.push(data.toString());
     });
 
+    const timer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      proc.kill("SIGTERM");
+      resolve({
+        stdout: stdout.join(""),
+        stderr: stderr.join("") + "\n\n[TIMEOUT] Command execution timed out",
+        exitCode: null,
+      });
+    }, timeoutMs);
+
     proc.on("close", (code) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
       resolve({
         stdout: stdout.join(""),
         stderr: stderr.join(""),
@@ -99,22 +136,15 @@ export function executeBash(
     });
 
     proc.on("error", (err) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
       resolve({
         stdout: "",
         stderr: err.message,
         exitCode: null,
       });
     });
-
-    // Timeout protection
-    setTimeout(() => {
-      proc.kill("SIGTERM");
-      resolve({
-        stdout: stdout.join(""),
-        stderr: stderr.join("") + "\n\n[TIMEOUT] Command execution timed out",
-        exitCode: null,
-      });
-    }, timeoutMs);
   });
 }
 
@@ -122,10 +152,11 @@ export function executeBash(
  * Create a bash plugin that provides command execution capability
  */
 export function createBashPlugin(options: BashPluginOptions = {}): ToolPlugin {
-  const { maxBytes, maxLines, timeoutMs } = {
+  const { maxBytes, maxLines, timeoutMs, sandbox } = {
     maxBytes: DEFAULT_MAX_BYTES,
     maxLines: DEFAULT_MAX_LINES,
     timeoutMs: DEFAULT_TIMEOUT_MS,
+    sandbox: undefined as BashPluginOptions["sandbox"],
     ...options,
   };
 
@@ -173,7 +204,23 @@ export function createBashPlugin(options: BashPluginOptions = {}): ToolPlugin {
         },
         async (args: { command: string; cwd?: string }) => {
           const cwd = args.cwd || process.cwd();
-          const result = await executeBash(args.command, cwd, timeoutMs);
+
+          const ac = new AbortController();
+          const timer = setTimeout(() => ac.abort(), timeoutMs);
+
+          let result: {
+            stdout: string;
+            stderr: string;
+            exitCode: number | null;
+          };
+          try {
+            result = sandbox
+              ? await sandbox(args.command, { cwd, signal: ac.signal })
+              : await executeBash(args.command, cwd, timeoutMs);
+          } finally {
+            clearTimeout(timer);
+          }
+
           const { output, truncated } = truncateOutput(
             result.stdout,
             result.stderr,
@@ -191,7 +238,7 @@ export function createBashPlugin(options: BashPluginOptions = {}): ToolPlugin {
 
           return {
             content: [{ type: "text", text: finalOutput }],
-            isError: result.exitCode !== null && result.exitCode !== 0,
+            isError: result.exitCode === null || result.exitCode !== 0,
           };
         },
         { internal: true },

--- a/packages/core/tests/plugins/bash_plugin_test.ts
+++ b/packages/core/tests/plugins/bash_plugin_test.ts
@@ -1,0 +1,136 @@
+/**
+ * E2E tests for core bash plugin (default + sandbox mode)
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { mcpc } from "../../mod.ts";
+import { createBashPlugin } from "../../src/plugins/bash.ts";
+
+const AGENT_NAME = "agent";
+const TOOL_NAME = `${AGENT_NAME}__bash`;
+
+// deno-lint-ignore no-explicit-any
+function execBash(server: any, command: string, cwd?: string) {
+  return server.callTool(TOOL_NAME, { command, cwd });
+}
+
+Deno.test("bash — default mode executes real bash", async () => {
+  const server = await mcpc(
+    [{ name: "test-bash-default", version: "1.0.0" }, {}],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashPlugin()],
+    }],
+  );
+
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await execBash(server, "echo hello-world");
+    assertEquals(r.isError, false);
+    assertStringIncludes(r.content[0].text, "hello-world");
+  } finally {
+    await server.close?.();
+  }
+});
+
+Deno.test("bash — sandbox replaces default execution", async () => {
+  let sandboxCalled = false;
+  let receivedCommand = "";
+
+  const sandbox = (
+    command: string,
+    _opts: { cwd: string; signal: AbortSignal },
+  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> => {
+    sandboxCalled = true;
+    receivedCommand = command;
+    return Promise.resolve({
+      stdout: `SANDBOX:${command}`,
+      stderr: "",
+      exitCode: 0,
+    });
+  };
+
+  const server = await mcpc(
+    [{ name: "test-bash-sandbox", version: "1.0.0" }, {}],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashPlugin({ sandbox })],
+    }],
+  );
+
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await execBash(server, "ls -la");
+    assertEquals(sandboxCalled, true);
+    assertEquals(receivedCommand, "ls -la");
+    assertEquals(r.isError, false);
+    assertStringIncludes(r.content[0].text, "SANDBOX:ls -la");
+  } finally {
+    await server.close?.();
+  }
+});
+
+Deno.test("bash — sandbox exitCode non-zero sets isError", async () => {
+  const sandbox = () =>
+    Promise.resolve({
+      stdout: "",
+      stderr: "boom",
+      exitCode: 1,
+    });
+
+  const server = await mcpc(
+    [{ name: "test-bash-err", version: "1.0.0" }, {}],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashPlugin({ sandbox })],
+    }],
+  );
+
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await execBash(server, "whatever");
+    assertEquals(r.isError, true);
+    assertStringIncludes(r.content[0].text, "boom");
+  } finally {
+    await server.close?.();
+  }
+});
+
+Deno.test("bash — sandbox receives cwd from args", async () => {
+  let receivedCwd = "";
+
+  const sandbox = (
+    _command: string,
+    opts: { cwd: string; signal: AbortSignal },
+  ) => {
+    receivedCwd = opts.cwd;
+    return Promise.resolve({ stdout: "ok", stderr: "", exitCode: 0 });
+  };
+
+  const server = await mcpc(
+    [{ name: "test-bash-cwd", version: "1.0.0" }, {}],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashPlugin({ sandbox })],
+    }],
+  );
+
+  try {
+    // deno-lint-ignore no-explicit-any
+    await (server.callTool as any)(TOOL_NAME, {
+      command: "pwd",
+      cwd: "/tmp",
+    });
+    assertEquals(receivedCwd, "/tmp");
+  } finally {
+    await server.close?.();
+  }
+});

--- a/packages/plugin-bash-exec/deno.json
+++ b/packages/plugin-bash-exec/deno.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mcpc/plugin-bash-exec",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcpc-tech/mcpc.git"
+  },
+  "exports": {
+    ".": "./mod.ts",
+    "./plugin": "./src/plugin.ts"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.8.0",
+    "@mcpc/core": "jsr:@mcpc/core@^0.3.45",
+    "secure-exec": "npm:secure-exec@^0.2.1"
+  },
+  "publish": {
+    "exclude": [
+      "examples/**",
+      "tests/**"
+    ]
+  },
+  "tasks": {
+    "dev": "deno run --allow-all examples/basic-usage.ts",
+    "test": "deno test --allow-all tests/"
+  }
+}

--- a/packages/plugin-bash-exec/examples/basic-usage.ts
+++ b/packages/plugin-bash-exec/examples/basic-usage.ts
@@ -1,0 +1,46 @@
+/**
+ * Basic usage example for @mcpc/plugin-bash-exec
+ *
+ * Run: deno run --allow-all examples/basic-usage.ts
+ */
+
+import { mcpc } from "@mcpc/core";
+import { createBashExecPlugin } from "../mod.ts";
+
+const server = await mcpc(
+  [{ name: "demo", version: "0.0.1" }, { capabilities: { tools: {} } }],
+  [{
+    name: "agent",
+    description: "Demo agent with secure-exec mediated CLI execution",
+    deps: { mcpServers: {} },
+    plugins: [
+      createBashExecPlugin({
+        allowCommands: ["bash", "whoami", "pwd"],
+        envMode: "allowlist",
+        envAllowlist: ["USER", "HOME"],
+      }),
+    ],
+  }],
+);
+
+const tool = "agent__bash_exec";
+
+const r1 = await server.callTool(tool, {
+  command: "echo hello-from-bash-exec",
+}) as any;
+console.log("shell command:", r1.content[0].text.trim());
+
+const r2 = await server.callTool(tool, {
+  binary: "whoami",
+  args: [],
+}) as any;
+console.log("direct cli:", r2.content[0].text.trim());
+
+const r3 = await server.callTool(tool, {
+  binary: "pwd",
+  args: [],
+  cwd: Deno.cwd(),
+}) as any;
+console.log("cwd:", r3.content[0].text.trim());
+
+await server.close?.();

--- a/packages/plugin-bash-exec/mod.ts
+++ b/packages/plugin-bash-exec/mod.ts
@@ -1,0 +1,22 @@
+/**
+ * @mcpc/plugin-bash-exec
+ *
+ * Real bash / CLI execution plugin using secure-exec policy mediation.
+ *
+ * @example
+ * ```typescript
+ * import { createBashExecPlugin } from "@mcpc/plugin-bash-exec";
+ * { plugins: [createBashExecPlugin({ allowCommands: ["whoami", "pwd"] })] }
+ * ```
+ */
+
+export {
+  type BashExecPluginOptions,
+  type CliEnvMode,
+  type CliPolicyOptions,
+  createBashExecPlugin,
+  createPlugin,
+} from "./src/plugin.ts";
+
+export { default as bashExecPlugin } from "./src/plugin.ts";
+export { default } from "./src/plugin.ts";

--- a/packages/plugin-bash-exec/src/plugin.ts
+++ b/packages/plugin-bash-exec/src/plugin.ts
@@ -1,0 +1,511 @@
+/**
+ * plugin-bash-exec — real bash / CLI execution via secure-exec policy mediation
+ *
+ * Features:
+ *   - Runs real host CLI tools through secure-exec's child-process bridge
+ *   - Concurrency limiting (semaphore)
+ *   - Per-call timeout enforcement
+ *   - Policy checks over command, args, cwd, and env
+ *   - Output truncation (bytes + lines)
+ */
+
+import path from "node:path";
+import process from "node:process";
+import type { ComposeStartContext, ToolPlugin } from "@mcpc/core";
+
+export type CliEnvMode = "inherit" | "empty" | "allowlist";
+
+export interface CliPolicyOptions {
+  allowCommands?: string[];
+  denyCommands?: string[];
+  allowArgs?: Record<string, string[][]>;
+  denyArgs?: Record<string, string[][]>;
+  allowCwdPrefixes?: string[];
+  envMode?: CliEnvMode;
+  envAllowlist?: string[];
+}
+
+export interface BashExecPluginOptions extends CliPolicyOptions {
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  concurrency?: number;
+  maxBytes?: number;
+  maxLines?: number;
+  defaultCwd?: string;
+  shellBinary?: string;
+  shellArgs?: string[];
+}
+
+interface ResolvedExecution {
+  binary: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+}
+
+const DEFAULTS = {
+  env: {} as Record<string, string>,
+  timeoutMs: 10_000,
+  concurrency: 4,
+  maxBytes: 50_000,
+  maxLines: 1_000,
+  defaultCwd: "",
+  shellBinary: "bash",
+  shellArgs: ["-c"],
+  envMode: "inherit" as CliEnvMode,
+};
+
+function createSemaphore(limit: number) {
+  limit = Math.max(limit, 1);
+  let active = 0;
+  const queue: Array<() => void> = [];
+  return async function acquire<T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= limit) {
+      await new Promise<void>((r) => queue.push(r));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      queue.shift()?.();
+    }
+  };
+}
+
+function truncate(text: string, maxBytes: number, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length > maxLines) {
+    return (
+      `[TRUNCATED] last ${maxLines} of ${lines.length} lines\n\n` +
+      lines.slice(-maxLines).join("\n")
+    );
+  }
+  if (text.length > maxBytes) {
+    return (
+      `[TRUNCATED] last ${maxBytes} of ${text.length} bytes\n\n` +
+      text.slice(-maxBytes)
+    );
+  }
+  return text;
+}
+
+function matchesCommand(command: string, pattern: string): boolean {
+  if (pattern.includes("/")) {
+    return command === pattern;
+  }
+  // pattern is bare name: only match bare command (no path separator)
+  return command === pattern;
+}
+
+function collectArgPatterns(
+  rules: Record<string, string[][]> | undefined,
+  command: string,
+): string[][] {
+  if (!rules) return [];
+  return Object.entries(rules)
+    .filter(([key]) => matchesCommand(command, key))
+    .flatMap(([, patterns]) => patterns);
+}
+
+function matchesArgPattern(args: string[], pattern: string[]): boolean {
+  if (pattern.length !== args.length) return false;
+  return pattern.every((value, index) => args[index] === value);
+}
+
+function isWithinPrefix(target: string, prefix: string): boolean {
+  const resolvedTarget = path.resolve(target);
+  const resolvedPrefix = path.resolve(prefix);
+  return resolvedTarget === resolvedPrefix ||
+    resolvedTarget.startsWith(`${resolvedPrefix}${path.sep}`);
+}
+
+function evaluateCliPolicy(
+  binary: string,
+  args: string[],
+  cwd: string,
+  policy: CliPolicyOptions,
+): string | null {
+  if (policy.denyCommands?.some((pattern) => matchesCommand(binary, pattern))) {
+    return `Command denied by policy: ${binary}`;
+  }
+
+  if (
+    policy.allowCommands?.length &&
+    !policy.allowCommands.some((pattern) => matchesCommand(binary, pattern))
+  ) {
+    return `Command not allowed by policy: ${binary}`;
+  }
+
+  if (
+    policy.allowCwdPrefixes?.length &&
+    !policy.allowCwdPrefixes.some((prefix) => isWithinPrefix(cwd, prefix))
+  ) {
+    return `Working directory not allowed by policy: ${cwd}`;
+  }
+
+  const denyPatterns = collectArgPatterns(policy.denyArgs, binary);
+  if (denyPatterns.some((pattern) => matchesArgPattern(args, pattern))) {
+    return `Arguments denied by policy for command: ${binary}`;
+  }
+
+  const allowPatterns = collectArgPatterns(policy.allowArgs, binary);
+  if (
+    allowPatterns.length > 0 &&
+    !allowPatterns.some((pattern) => matchesArgPattern(args, pattern))
+  ) {
+    return `Arguments not allowed by policy for command: ${binary}`;
+  }
+
+  return null;
+}
+
+function buildEnv(
+  injectedEnv: Record<string, string>,
+  policy: CliPolicyOptions,
+): Record<string, string> {
+  const hostEnv: Record<string, string> = {};
+  for (
+    const [k, v] of Object.entries(
+      Deno.env.toObject() as Record<string, string | undefined>,
+    )
+  ) {
+    if (v != null) hostEnv[k] = v;
+  }
+
+  let baseEnv: Record<string, string>;
+  switch (policy.envMode ?? "inherit") {
+    case "empty":
+      baseEnv = {};
+      break;
+    case "allowlist":
+      baseEnv = Object.fromEntries(
+        (policy.envAllowlist ?? [])
+          .filter((key) => key in hostEnv)
+          .map((key) => [key, hostEnv[key] ?? ""]),
+      );
+      break;
+    case "inherit":
+    default:
+      baseEnv = hostEnv;
+      break;
+  }
+
+  return { ...baseEnv, ...injectedEnv };
+}
+
+function resolveExecution(
+  args: { command?: string; binary?: string; args?: string[]; cwd?: string },
+  cfg: BashExecPluginOptions,
+): ResolvedExecution | { error: string } {
+  const cwd = args.cwd ?? cfg.defaultCwd ?? process.cwd();
+  const env = buildEnv(cfg.env ?? {}, cfg);
+
+  if (args.binary) {
+    return {
+      binary: args.binary,
+      args: args.args ?? [],
+      cwd,
+      env,
+    };
+  }
+
+  if (args.command) {
+    return {
+      binary: cfg.shellBinary ?? "bash",
+      args: [...(cfg.shellArgs ?? ["-c"]), args.command],
+      cwd,
+      env,
+    };
+  }
+
+  return { error: "Provide either `command` or `binary`." };
+}
+
+function buildRunnerScript(
+  execution: ResolvedExecution,
+  timeoutMs: number,
+): string {
+  return `
+const { spawn } = require("node:child_process");
+const binary = ${JSON.stringify(execution.binary)};
+const args = ${JSON.stringify(execution.args)};
+const cwd = ${JSON.stringify(execution.cwd)};
+const env = ${JSON.stringify(execution.env)};
+const timeoutMs = ${JSON.stringify(timeoutMs)};
+
+const child = spawn(binary, args, {
+  cwd,
+  env,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let finished = false;
+const timer = setTimeout(() => {
+  if (finished) return;
+  child.kill("SIGTERM");
+  process.stderr.write("[TIMEOUT] Command exceeded " + timeoutMs + "ms\\n");
+}, timeoutMs);
+
+child.stdout.on("data", (data) => process.stdout.write(data));
+child.stderr.on("data", (data) => process.stderr.write(data));
+
+child.on("error", (err) => {
+  finished = true;
+  clearTimeout(timer);
+  process.stderr.write(String(err?.message ?? err));
+  process.exit(1);
+});
+
+child.on("close", (code, signal) => {
+  finished = true;
+  clearTimeout(timer);
+  if (signal) {
+    process.exit(124);
+  }
+  process.exit(code ?? 0);
+});
+`;
+}
+
+async function runSecureCli(
+  execution: ResolvedExecution,
+  cfg: BashExecPluginOptions,
+): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  errorMessage: string;
+  timedOut: boolean;
+}> {
+  const {
+    NodeRuntime,
+    createNodeDriver,
+    createNodeRuntimeDriverFactory,
+    createInMemoryFileSystem,
+    createNodeHostCommandExecutor,
+    allowAllFs,
+    // deno-lint-ignore no-explicit-any
+  } = await import("secure-exec") as any;
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let fallbackTimedOut = false;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULTS.timeoutMs;
+
+  const runtime = new NodeRuntime({
+    systemDriver: createNodeDriver({
+      filesystem: createInMemoryFileSystem(),
+      commandExecutor: createNodeHostCommandExecutor(),
+      permissions: {
+        ...allowAllFs,
+        childProcess: (
+          request: { command: string; args: string[]; cwd?: string },
+        ) => {
+          const reason = evaluateCliPolicy(
+            request.command,
+            request.args,
+            request.cwd ?? execution.cwd,
+            cfg,
+          );
+          return reason ? { allow: false, reason } : { allow: true };
+        },
+      },
+      processConfig: { cwd: execution.cwd },
+    }),
+    runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+    onStdio: (event: { channel: string; message: string }) => {
+      if (event.channel === "stdout") stdout.push(event.message);
+      else stderr.push(event.message);
+    },
+  });
+
+  const fallbackTimer = setTimeout(() => {
+    fallbackTimedOut = true;
+    runtime.terminate?.();
+  }, timeoutMs + 1_000);
+
+  try {
+    const result = await runtime.exec(
+      buildRunnerScript(execution, timeoutMs),
+    );
+    const stderrText = stderr.join("");
+    return {
+      stdout: stdout.join(""),
+      stderr: stderrText,
+      exitCode: result.code ?? 0,
+      errorMessage: result.errorMessage ?? "",
+      timedOut: fallbackTimedOut || stderrText.includes("[TIMEOUT]"),
+    };
+  } catch (err) {
+    return {
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+      exitCode: null,
+      errorMessage: err instanceof Error ? err.message : String(err),
+      timedOut: fallbackTimedOut,
+    };
+  } finally {
+    clearTimeout(fallbackTimer);
+    await runtime.terminate?.();
+  }
+}
+
+export function createBashExecPlugin(
+  options: BashExecPluginOptions = {},
+): ToolPlugin {
+  const cfg = { ...DEFAULTS, ...options };
+  if (!cfg.defaultCwd) {
+    cfg.defaultCwd = process.cwd();
+  }
+
+  const semaphore = createSemaphore(cfg.concurrency);
+  // deno-lint-ignore no-explicit-any
+  let serverRef: any = null;
+
+  return {
+    name: "plugin-bash-exec",
+    version: "0.0.1",
+
+    configureServer(server) {
+      serverRef = server;
+    },
+
+    composeStart(context: ComposeStartContext) {
+      if (!serverRef) return;
+
+      const toolName = `${context.serverName}__bash_exec`;
+
+      serverRef.tool(
+        toolName,
+        "Execute a real bash command or CLI binary through secure-exec policy mediation.\n\n" +
+          "Modes:\n" +
+          "- command: runs through the configured shell binary\n" +
+          "- binary + args: direct CLI execution with policy checks",
+        {
+          type: "object",
+          properties: {
+            command: {
+              type: "string",
+              description:
+                "Shell command to run through the configured shell binary",
+            },
+            binary: {
+              type: "string",
+              description: "Real CLI binary to execute directly",
+            },
+            args: {
+              type: "array",
+              items: { type: "string" },
+              description: "Arguments for direct CLI execution",
+            },
+            cwd: {
+              type: "string",
+              description: "Working directory for the command or binary",
+            },
+          },
+        } as const,
+        (
+          args: {
+            command?: string;
+            binary?: string;
+            args?: string[];
+            cwd?: string;
+          },
+        ) => {
+          return semaphore(async () => {
+            const resolved = resolveExecution(args, cfg);
+            if ("error" in resolved) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: `[ERROR] ${resolved.error}`,
+                }],
+                isError: true,
+              };
+            }
+
+            const policyError = evaluateCliPolicy(
+              resolved.binary,
+              resolved.args,
+              resolved.cwd,
+              cfg,
+            );
+            if (policyError) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: `[DENIED] ${policyError}`,
+                }],
+                isError: true,
+              };
+            }
+
+            const result = await runSecureCli(resolved, cfg);
+            const combined =
+              (result.stderr ? `STDERR:\n${result.stderr}\n\nSTDOUT:\n` : "") +
+              result.stdout;
+
+            let output = result.timedOut
+              ? result.stderr.includes("[TIMEOUT]")
+                ? result.stderr
+                : `[TIMEOUT] Command exceeded ${cfg.timeoutMs}ms\n\n` +
+                  truncate(combined, cfg.maxBytes, cfg.maxLines)
+              : truncate(combined, cfg.maxBytes, cfg.maxLines);
+
+            if (result.errorMessage) {
+              output = `[ERROR] ${result.errorMessage}\n\n` + output;
+            } else if (
+              !result.timedOut && result.exitCode !== 0 &&
+              result.exitCode != null
+            ) {
+              output = `[EXIT CODE: ${result.exitCode}]\n` + output;
+            }
+
+            const isError = result.timedOut ||
+              result.exitCode === null ||
+              (result.exitCode !== null && result.exitCode !== 0) ||
+              !!result.errorMessage;
+
+            return {
+              content: [{ type: "text" as const, text: output }],
+              ...(isError ? { isError: true } : {}),
+            };
+          });
+        },
+        { internal: true },
+      );
+    },
+  };
+}
+
+export function createPlugin(params: Record<string, string>): ToolPlugin {
+  const opts: BashExecPluginOptions = {};
+  if (params.timeoutMs) opts.timeoutMs = parseInt(params.timeoutMs, 10) || 0;
+  if (params.concurrency) {
+    opts.concurrency = parseInt(params.concurrency, 10) || 0;
+  }
+  if (params.maxBytes) opts.maxBytes = parseInt(params.maxBytes, 10) || 0;
+  if (params.maxLines) opts.maxLines = parseInt(params.maxLines, 10) || 0;
+  if (params.defaultCwd) opts.defaultCwd = params.defaultCwd;
+  if (params.shellBinary) opts.shellBinary = params.shellBinary;
+  if (params.shellArgs) {
+    opts.shellArgs = params.shellArgs.split(",").filter(Boolean);
+  }
+  if (params.envMode) opts.envMode = params.envMode as CliEnvMode;
+  if (params.allowCommands) {
+    opts.allowCommands = params.allowCommands.split(",").filter(Boolean);
+  }
+  if (params.denyCommands) {
+    opts.denyCommands = params.denyCommands.split(",").filter(Boolean);
+  }
+  if (params.allowCwdPrefixes) {
+    opts.allowCwdPrefixes = params.allowCwdPrefixes.split(",").filter(Boolean);
+  }
+  if (params.envAllowlist) {
+    opts.envAllowlist = params.envAllowlist.split(",").filter(Boolean);
+  }
+  return createBashExecPlugin(opts);
+}
+
+export default createBashExecPlugin;

--- a/packages/plugin-bash-exec/tests/bash_exec.test.ts
+++ b/packages/plugin-bash-exec/tests/bash_exec.test.ts
@@ -1,0 +1,201 @@
+/**
+ * E2E tests for plugin-bash-exec
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { mcpc } from "@mcpc/core";
+import { createBashExecPlugin } from "../mod.ts";
+
+const AGENT_NAME = "agent";
+const TOOL_NAME = `${AGENT_NAME}__bash_exec`;
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+function makeServer(
+  pluginOpts: Parameters<typeof createBashExecPlugin>[0] = {},
+) {
+  return mcpc(
+    [{ name: "test-bash-exec", version: "0.0.1" }, {
+      capabilities: { tools: {} },
+    }],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashExecPlugin(pluginOpts)],
+    }],
+  );
+}
+
+async function createScript(body: string) {
+  const dir = await Deno.makeTempDir({ prefix: "bash-exec-cli-" });
+  const scriptPath = `${dir}/tool.sh`;
+  await Deno.writeTextFile(
+    scriptPath,
+    `#!/usr/bin/env bash
+set -eu
+${body}
+`,
+  );
+  await Deno.chmod(scriptPath, 0o755);
+  return { dir, scriptPath };
+}
+
+// deno-lint-ignore no-explicit-any
+function callTool(server: any, args: Record<string, unknown>) {
+  return server.callTool(TOOL_NAME, args);
+}
+
+Deno.test(
+  { name: "bash_exec — shell command mode still works", ...TEST_OPTS },
+  async () => {
+    const server = await makeServer({ allowCommands: ["bash"] });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, {
+        command: "echo hello-from-shell",
+      });
+      assertEquals(r.isError, undefined);
+      assertStringIncludes(r.content[0].text, "hello-from-shell");
+    } finally {
+      await server.close?.();
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — direct custom CLI succeeds", ...TEST_OPTS },
+  async () => {
+    const { dir, scriptPath } = await createScript(
+      'printf "custom:%s:%s\\n" "$1" "${MY_VAR:-missing}"',
+    );
+    const server = await makeServer({
+      env: { MY_VAR: "hello" },
+      envMode: "empty",
+      allowCommands: [scriptPath],
+    });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, {
+        binary: scriptPath,
+        args: ["world"],
+      });
+      assertEquals(r.isError, undefined);
+      assertStringIncludes(r.content[0].text, "custom:world:hello");
+    } finally {
+      await server.close?.();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — denied binary is blocked", ...TEST_OPTS },
+  async () => {
+    const server = await makeServer({ denyCommands: ["whoami"] });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, { binary: "whoami" });
+      assertEquals(r.isError, true);
+      assertStringIncludes(r.content[0].text, "DENIED");
+    } finally {
+      await server.close?.();
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — argument policy is enforced", ...TEST_OPTS },
+  async () => {
+    const { dir, scriptPath } = await createScript('printf "arg:%s\\n" "$1"');
+    const server = await makeServer({
+      allowCommands: [scriptPath],
+      allowArgs: {
+        [scriptPath]: [["--ok"]],
+      },
+    });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, {
+        binary: scriptPath,
+        args: ["--blocked"],
+      });
+      assertEquals(r.isError, true);
+      assertStringIncludes(r.content[0].text, "DENIED");
+    } finally {
+      await server.close?.();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — cwd restriction is enforced", ...TEST_OPTS },
+  async () => {
+    const { dir, scriptPath } = await createScript("pwd");
+    const allowedDir = await Deno.makeTempDir({ prefix: "bash-exec-allowed-" });
+    const blockedDir = await Deno.makeTempDir({ prefix: "bash-exec-blocked-" });
+    const server = await makeServer({
+      allowCommands: [scriptPath],
+      allowCwdPrefixes: [allowedDir],
+    });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, {
+        binary: scriptPath,
+        cwd: blockedDir,
+      });
+      assertEquals(r.isError, true);
+      assertStringIncludes(r.content[0].text, "DENIED");
+    } finally {
+      await server.close?.();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+      await Deno.remove(allowedDir, { recursive: true }).catch(() => {});
+      await Deno.remove(blockedDir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — env allowlist is enforced", ...TEST_OPTS },
+  async () => {
+    const { dir, scriptPath } = await createScript(
+      'printf "visible:%s secret:%s\\n" "${VISIBLE:-missing}" "${HOST_SECRET:-missing}"',
+    );
+    const server = await makeServer({
+      env: { VISIBLE: "from-host" },
+      allowCommands: [scriptPath],
+      envMode: "allowlist",
+      envAllowlist: ["VISIBLE"],
+    });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, { binary: scriptPath });
+      assertEquals(r.isError, undefined);
+      assertStringIncludes(r.content[0].text, "visible:from-host");
+      assertStringIncludes(r.content[0].text, "secret:missing");
+    } finally {
+      await server.close?.();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
+  { name: "bash_exec — timeout aborts long-running cli", ...TEST_OPTS },
+  async () => {
+    const { dir, scriptPath } = await createScript("sleep 2");
+    const server = await makeServer({
+      timeoutMs: 200,
+      allowCommands: [scriptPath],
+    });
+    try {
+      // deno-lint-ignore no-explicit-any
+      const r: any = await callTool(server, { binary: scriptPath });
+      assertEquals(r.isError, true);
+      assertStringIncludes(r.content[0].text, "TIMEOUT");
+    } finally {
+      await server.close?.();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
+);

--- a/packages/plugin-bash-just/deno.json
+++ b/packages/plugin-bash-just/deno.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mcpc/plugin-bash-just",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcpc-tech/mcpc.git"
+  },
+  "exports": {
+    ".": "./mod.ts",
+    "./plugin": "./src/plugin.ts"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.8.0",
+    "@mcpc/core": "jsr:@mcpc/core@^0.3.45",
+    "just-bash": "npm:just-bash@^3.0.1"
+  },
+  "publish": {
+    "exclude": [
+      "examples/**",
+      "tests/**"
+    ]
+  },
+  "tasks": {
+    "dev": "deno run --allow-all examples/basic-usage.ts",
+    "test": "deno test --allow-all tests/"
+  }
+}

--- a/packages/plugin-bash-just/examples/basic-usage.ts
+++ b/packages/plugin-bash-just/examples/basic-usage.ts
@@ -1,0 +1,54 @@
+/**
+ * Basic usage example for @mcpc/plugin-bash-just
+ *
+ * Run: deno run --allow-all examples/basic-usage.ts
+ */
+
+import { mcpc } from "@mcpc/core";
+import { createBashJustPlugin } from "../mod.ts";
+
+const server = await mcpc(
+  [{ name: "demo", version: "0.0.1" }, { capabilities: { tools: {} } }],
+  [{
+    name: "agent",
+    description: "Demo agent with just-bash sandbox and optional CLI mode",
+    deps: { mcpServers: {} },
+    plugins: [
+      createBashJustPlugin({
+        fsMode: "memory",
+        initialFiles: {
+          "/data/hello.txt": "Hello from the sandbox!\n",
+        },
+        env: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          GREETING: "world",
+        },
+        cli: {
+          enabled: true,
+          allowCommands: ["whoami"],
+          envMode: "empty",
+        },
+      }),
+    ],
+  }],
+);
+
+const tool = "agent__bash_just";
+
+const r1 = await server.callTool(tool, {
+  command: "echo Hello, $GREETING!",
+}) as any;
+console.log("interpreted:", r1.content[0].text.trim());
+
+const r2 = await server.callTool(tool, {
+  command: "cat /data/hello.txt",
+}) as any;
+console.log("seeded file:", r2.content[0].text.trim());
+
+const r3 = await server.callTool(tool, {
+  binary: "whoami",
+  args: [],
+}) as any;
+console.log("real cli:", r3.content[0].text.trim());
+
+await server.close?.();

--- a/packages/plugin-bash-just/mod.ts
+++ b/packages/plugin-bash-just/mod.ts
@@ -1,0 +1,33 @@
+/**
+ * @mcpc/plugin-bash-just
+ *
+ * Sandboxed bash execution plugin using just-bash (in-memory interpreter).
+ * No host filesystem or process.env access unless explicitly configured.
+ *
+ * @example
+ * ```typescript
+ * // Default: fully in-memory, zero host access
+ * { plugins: [createBashJustPlugin()] }
+ *
+ * // Enable direct CLI execution with policy controls
+ * { plugins: [createBashJustPlugin({ cli: { enabled: true, allowCommands: ["whoami"] } })] }
+ * ```
+ */
+
+export {
+  type BashJustCliOptions,
+  type BashJustPluginOptions,
+  type CliEnvMode,
+  type CliExecutionRequest,
+  type CliExecutionResult,
+  type CliExecutor,
+  type CliPolicyOptions,
+  createBashJustPlugin,
+  type FsMode,
+  type SandboxFn,
+  type SandboxResult,
+} from "./src/plugin.ts";
+
+export { default as bashJustPlugin } from "./src/plugin.ts";
+export { createBashJustPlugin as createPlugin } from "./src/plugin.ts";
+export { default } from "./src/plugin.ts";

--- a/packages/plugin-bash-just/src/plugin.ts
+++ b/packages/plugin-bash-just/src/plugin.ts
@@ -1,0 +1,648 @@
+/**
+ * plugin-bash-just — sandboxed bash execution via just-bash
+ *
+ * Three filesystem modes:
+ *   - "memory"    (default) — pure in-memory FS, zero host access
+ *   - "overlay"   — reads from rootDir, writes stay in memory (copy-on-write)
+ *   - "readwrite" — full read/write scoped under rootDir
+ *
+ * Features:
+ *   - Concurrency limiting (semaphore)
+ *   - Per-call timeout via AbortController
+ *   - Explicit env injection (no process.env leakage)
+ *   - Execution limits (max commands, loop iterations, call depth)
+ *   - Output truncation (bytes + lines)
+ *   - Optional real CLI execution under policy control
+ */
+
+import path from "node:path";
+import { spawn } from "node:child_process";
+import process from "node:process";
+import type { ComposeStartContext, ToolPlugin } from "@mcpc/core";
+import type { Buffer } from "node:buffer";
+
+export type FsMode = "memory" | "overlay" | "readwrite";
+export type CliEnvMode = "inherit" | "empty" | "allowlist";
+
+export interface SandboxResult {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+export interface CliExecutionRequest {
+  binary: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  signal: AbortSignal;
+}
+
+export interface CliExecutionResult {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+}
+
+export type SandboxFn = (
+  command: string,
+  options: { cwd: string; env: Record<string, string>; signal: AbortSignal },
+) => Promise<SandboxResult>;
+
+export type CliExecutor = (
+  request: CliExecutionRequest,
+) => Promise<CliExecutionResult>;
+
+export interface CliPolicyOptions {
+  allowCommands?: string[];
+  denyCommands?: string[];
+  allowArgs?: Record<string, string[][]>;
+  denyArgs?: Record<string, string[][]>;
+  allowCwdPrefixes?: string[];
+  envMode?: CliEnvMode;
+  envAllowlist?: string[];
+}
+
+export interface BashJustCliOptions extends CliPolicyOptions {
+  enabled?: boolean;
+  defaultCwd?: string;
+  executor?: CliExecutor;
+}
+
+export interface BashJustPluginOptions {
+  fsMode?: FsMode;
+  rootDir?: string;
+  initialFiles?: Record<string, string>;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  concurrency?: number;
+  maxBytes?: number;
+  maxLines?: number;
+  maxCommandCount?: number;
+  maxLoopIterations?: number;
+  maxCallDepth?: number;
+  sandbox?: SandboxFn;
+  cli?: BashJustCliOptions;
+}
+
+const DEFAULTS = {
+  fsMode: "memory" as FsMode,
+  rootDir: "",
+  initialFiles: {} as Record<string, string>,
+  env: { PATH: "/usr/local/bin:/usr/bin:/bin", LANG: "C.UTF-8" } as Record<
+    string,
+    string
+  >,
+  timeoutMs: 30_000,
+  concurrency: 4,
+  maxBytes: 100_000,
+  maxLines: 2_000,
+  maxCommandCount: 500,
+  maxLoopIterations: 10_000,
+  maxCallDepth: 50,
+  cli: {
+    enabled: false,
+    envMode: "empty" as CliEnvMode,
+  } as BashJustCliOptions,
+};
+
+function createSemaphore(limit: number) {
+  limit = Math.max(limit, 1);
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function acquire<T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= limit) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      queue.shift()?.();
+    }
+  };
+}
+
+function truncateOutput(
+  text: string,
+  maxBytes: number,
+  maxLines: number,
+): string {
+  const lines = text.split("\n");
+  if (lines.length > maxLines) {
+    return (
+      `[TRUNCATED] showing last ${maxLines} of ${lines.length} lines\n\n` +
+      lines.slice(-maxLines).join("\n")
+    );
+  }
+  if (text.length > maxBytes) {
+    return (
+      `[TRUNCATED] showing last ${maxBytes} bytes of ${text.length}\n\n` +
+      text.slice(-maxBytes)
+    );
+  }
+  return text;
+}
+
+function matchesCommand(command: string, pattern: string): boolean {
+  if (pattern.includes("/")) {
+    return command === pattern;
+  }
+  // pattern is a bare name: only match bare command (no path separator)
+  return command === pattern;
+}
+
+function collectArgPatterns(
+  rules: Record<string, string[][]> | undefined,
+  command: string,
+): string[][] {
+  if (!rules) return [];
+  return Object.entries(rules)
+    .filter(([key]) => matchesCommand(command, key))
+    .flatMap(([, patterns]) => patterns);
+}
+
+function matchesArgPattern(args: string[], pattern: string[]): boolean {
+  if (pattern.length !== args.length) return false;
+  return pattern.every((value, index) => args[index] === value);
+}
+
+function isWithinPrefix(target: string, prefix: string): boolean {
+  const resolvedTarget = path.resolve(target);
+  const resolvedPrefix = path.resolve(prefix);
+  return resolvedTarget === resolvedPrefix ||
+    resolvedTarget.startsWith(`${resolvedPrefix}${path.sep}`);
+}
+
+function evaluateCliPolicy(
+  binary: string,
+  args: string[],
+  cwd: string,
+  policy: CliPolicyOptions,
+): string | null {
+  if (policy.denyCommands?.some((pattern) => matchesCommand(binary, pattern))) {
+    return `Command denied by policy: ${binary}`;
+  }
+
+  if (
+    policy.allowCommands?.length &&
+    !policy.allowCommands.some((pattern) => matchesCommand(binary, pattern))
+  ) {
+    return `Command not allowed by policy: ${binary}`;
+  }
+
+  if (
+    policy.allowCwdPrefixes?.length &&
+    !policy.allowCwdPrefixes.some((prefix) => isWithinPrefix(cwd, prefix))
+  ) {
+    return `Working directory not allowed by policy: ${cwd}`;
+  }
+
+  const denyPatterns = collectArgPatterns(policy.denyArgs, binary);
+  if (denyPatterns.some((pattern) => matchesArgPattern(args, pattern))) {
+    return `Arguments denied by policy for command: ${binary}`;
+  }
+
+  const allowPatterns = collectArgPatterns(policy.allowArgs, binary);
+  if (
+    allowPatterns.length > 0 &&
+    !allowPatterns.some((pattern) => matchesArgPattern(args, pattern))
+  ) {
+    return `Arguments not allowed by policy for command: ${binary}`;
+  }
+
+  return null;
+}
+
+function buildCliEnv(
+  injectedEnv: Record<string, string>,
+  policy: CliPolicyOptions,
+): Record<string, string> {
+  const hostEnv: Record<string, string> = {};
+  for (
+    const [k, v] of Object.entries(
+      process.env as Record<string, string | undefined>,
+    )
+  ) {
+    if (v != null) hostEnv[k] = v;
+  }
+
+  let baseEnv: Record<string, string>;
+  switch (policy.envMode ?? "empty") {
+    case "inherit":
+      baseEnv = hostEnv;
+      break;
+    case "allowlist":
+      baseEnv = Object.fromEntries(
+        (policy.envAllowlist ?? [])
+          .filter((key) => key in hostEnv)
+          .map((key) => [key, hostEnv[key] ?? ""]),
+      );
+      break;
+    case "empty":
+    default:
+      baseEnv = {};
+      break;
+  }
+
+  return { ...baseEnv, ...injectedEnv };
+}
+
+function runHostCli(
+  request: CliExecutionRequest,
+): Promise<CliExecutionResult> {
+  const child = spawn(request.binary, request.args, {
+    cwd: request.cwd,
+    env: { ...request.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+
+  const onAbort = () => {
+    timedOut = true;
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // process may already be gone
+    }
+  };
+  request.signal.addEventListener("abort", onAbort, { once: true });
+
+  return new Promise<CliExecutionResult>((resolve) => {
+    child.on("close", (code: number | null) => {
+      request.signal.removeEventListener("abort", onAbort);
+      if (timedOut || request.signal.aborted) {
+        resolve({
+          stdout,
+          stderr: stderr
+            ? `${stderr}
+[TIMEOUT] Command exceeded execution deadline`
+            : "[TIMEOUT] Command exceeded execution deadline",
+          exitCode: null,
+        });
+      } else {
+        resolve({
+          stdout,
+          stderr,
+          exitCode: code ?? 1,
+        });
+      }
+    });
+
+    child.on("error", (err: Error) => {
+      request.signal.removeEventListener("abort", onAbort);
+      resolve({
+        stdout: "",
+        stderr: `[ERROR] ${err.message}`,
+        exitCode: null,
+      });
+    });
+  });
+}
+
+function buildOutput(
+  stdout: string | undefined,
+  stderr: string | undefined,
+  exitCode: number | null | undefined,
+  maxBytes: number,
+  maxLines: number,
+): { text: string; isError?: true } {
+  const rawOutput = (stderr ? `STDERR:\n${stderr}\n\nSTDOUT:\n` : "") +
+    (stdout ?? "");
+  let output = truncateOutput(rawOutput, maxBytes, maxLines);
+  if (exitCode !== 0 && exitCode != null) {
+    output = `[EXIT CODE: ${exitCode}]\n` + output;
+  }
+  const isError = exitCode == null || exitCode !== 0;
+  return {
+    text: output,
+    ...(isError ? { isError: true as const } : {}),
+  };
+}
+
+export function createBashJustPlugin(
+  options: BashJustPluginOptions = {},
+): ToolPlugin {
+  const cfg = {
+    ...DEFAULTS,
+    ...options,
+    cli: {
+      ...DEFAULTS.cli,
+      ...options.cli,
+    },
+  };
+
+  if (!cfg.rootDir) {
+    cfg.rootDir = process.cwd();
+  }
+
+  const semaphore = createSemaphore(cfg.concurrency);
+  // deno-lint-ignore no-explicit-any
+  let serverRef: any = null;
+
+  return {
+    name: "plugin-bash-just",
+    version: "0.0.1",
+
+    configureServer(server) {
+      serverRef = server;
+    },
+
+    composeStart(context: ComposeStartContext) {
+      if (!serverRef) return;
+
+      const toolName = `${context.serverName}__bash_just`;
+
+      serverRef.tool(
+        toolName,
+        "Execute bash via just-bash, or run an approved real CLI under policy control.\n\n" +
+          "Modes:\n" +
+          "- command: interpreted by just-bash by default\n" +
+          "- binary + args: real CLI execution when CLI mode is enabled",
+        {
+          type: "object",
+          properties: {
+            command: {
+              type: "string",
+              description: "Bash command(s) to execute with just-bash",
+            },
+            binary: {
+              type: "string",
+              description:
+                "Real CLI binary to execute when CLI mode is enabled",
+            },
+            args: {
+              type: "array",
+              items: { type: "string" },
+              description: "Arguments for the real CLI binary",
+            },
+            cwd: {
+              type: "string",
+              description: "Working directory for the execution",
+            },
+          },
+        } as const,
+        (
+          args: {
+            command?: string;
+            binary?: string;
+            args?: string[];
+            cwd?: string;
+          },
+        ) => {
+          return semaphore(async () => {
+            if (!args.command && !args.binary) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: "[ERROR] Provide either `command` or `binary`.",
+                }],
+                isError: true,
+              };
+            }
+
+            if (args.binary) {
+              if (!cfg.cli.enabled) {
+                return {
+                  content: [{
+                    type: "text" as const,
+                    text:
+                      "[ERROR] Real CLI execution is not enabled for this plugin instance.",
+                  }],
+                  isError: true,
+                };
+              }
+
+              const cwd = args.cwd ?? cfg.cli.defaultCwd ?? process.cwd();
+              const cliArgs = args.args ?? [];
+              const policyError = evaluateCliPolicy(
+                args.binary,
+                cliArgs,
+                cwd,
+                cfg.cli,
+              );
+              if (policyError) {
+                return {
+                  content: [{
+                    type: "text" as const,
+                    text: `[DENIED] ${policyError}`,
+                  }],
+                  isError: true,
+                };
+              }
+
+              const ac = new AbortController();
+              const timer = setTimeout(() => ac.abort(), cfg.timeoutMs);
+              try {
+                const executor = cfg.cli.executor ?? runHostCli;
+                const result = await executor({
+                  binary: args.binary,
+                  args: cliArgs,
+                  cwd,
+                  env: buildCliEnv(cfg.env, cfg.cli),
+                  signal: ac.signal,
+                });
+                clearTimeout(timer);
+
+                const output = buildOutput(
+                  result.stdout,
+                  result.stderr,
+                  result.exitCode,
+                  cfg.maxBytes,
+                  cfg.maxLines,
+                );
+                return {
+                  content: [{ type: "text" as const, text: output.text }],
+                  ...(output.isError ? { isError: true } : {}),
+                };
+              } catch (err) {
+                clearTimeout(timer);
+                const isTimeout = err instanceof Error &&
+                  err.name === "AbortError";
+                const msg = isTimeout
+                  ? `[TIMEOUT] Command exceeded ${cfg.timeoutMs}ms`
+                  : `[ERROR] ${
+                    err instanceof Error ? err.message : String(err)
+                  }`;
+                return {
+                  content: [{ type: "text" as const, text: msg }],
+                  isError: true,
+                };
+              }
+            }
+
+            const {
+              Bash,
+              InMemoryFs,
+              OverlayFs,
+              ReadWriteFs,
+              // deno-lint-ignore no-explicit-any
+            } = await import("just-bash") as any;
+
+            let fs: unknown;
+            if (cfg.fsMode === "overlay") {
+              fs = new OverlayFs({ root: cfg.rootDir, mountPoint: "/" });
+            } else if (cfg.fsMode === "readwrite") {
+              fs = new ReadWriteFs({ root: cfg.rootDir });
+            } else {
+              const memFs = new InMemoryFs();
+              for (
+                const [filePath, content] of Object.entries(cfg.initialFiles)
+              ) {
+                await memFs.writeFile(
+                  filePath,
+                  new TextEncoder().encode(content),
+                );
+              }
+              fs = memFs;
+            }
+
+            const bash = new Bash({
+              fs,
+              env: cfg.env,
+              network: false,
+              defenseInDepth: false,
+              limits: {
+                maxCommandCount: cfg.maxCommandCount,
+                maxLoopIterations: cfg.maxLoopIterations,
+                maxCallDepth: cfg.maxCallDepth,
+              },
+            });
+
+            const ac = new AbortController();
+            const timer = setTimeout(() => ac.abort(), cfg.timeoutMs);
+
+            try {
+              if (cfg.sandbox) {
+                const sandboxResult = await cfg.sandbox(args.command!, {
+                  cwd: args.cwd ?? "/home/user",
+                  env: cfg.env,
+                  signal: ac.signal,
+                });
+                clearTimeout(timer);
+                const output = buildOutput(
+                  sandboxResult.stdout,
+                  sandboxResult.stderr,
+                  sandboxResult.exitCode,
+                  cfg.maxBytes,
+                  cfg.maxLines,
+                );
+                return {
+                  content: [{ type: "text" as const, text: output.text }],
+                  ...(output.isError ? { isError: true } : {}),
+                };
+              }
+
+              const result = await bash.exec(args.command!, {
+                cwd: args.cwd ?? "/home/user",
+                signal: ac.signal,
+              });
+              clearTimeout(timer);
+
+              const output = buildOutput(
+                result.stdout,
+                result.stderr,
+                result.exitCode,
+                cfg.maxBytes,
+                cfg.maxLines,
+              );
+              return {
+                content: [{ type: "text" as const, text: output.text }],
+                ...(output.isError ? { isError: true } : {}),
+              };
+            } catch (err) {
+              clearTimeout(timer);
+              const isTimeout = err instanceof Error &&
+                err.name === "AbortError";
+              const msg = isTimeout
+                ? `[TIMEOUT] Command exceeded ${cfg.timeoutMs}ms`
+                : `[ERROR] ${err instanceof Error ? err.message : String(err)}`;
+              return {
+                content: [{ type: "text" as const, text: msg }],
+                isError: true,
+              };
+            }
+          });
+        },
+        { internal: true },
+      );
+    },
+  };
+}
+
+export function createPlugin(params: Record<string, string>): ToolPlugin {
+  const opts: BashJustPluginOptions = {};
+
+  if (params.fsMode) opts.fsMode = params.fsMode as FsMode;
+  if (params.rootDir) opts.rootDir = params.rootDir;
+  if (params.timeoutMs) opts.timeoutMs = parseInt(params.timeoutMs, 10) || 0;
+  if (params.concurrency) {
+    opts.concurrency = parseInt(params.concurrency, 10) || 0;
+  }
+  if (params.maxBytes) opts.maxBytes = parseInt(params.maxBytes, 10) || 0;
+  if (params.maxLines) opts.maxLines = parseInt(params.maxLines, 10) || 0;
+  if (params.maxCommandCount) {
+    opts.maxCommandCount = parseInt(params.maxCommandCount, 10) || 0;
+  }
+  if (params.maxLoopIterations) {
+    opts.maxLoopIterations = parseInt(params.maxLoopIterations, 10) || 0;
+  }
+  if (params.cliEnabled) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      enabled: params.cliEnabled === "true",
+    };
+  }
+  if (params.cliDefaultCwd) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      defaultCwd: params.cliDefaultCwd,
+    };
+  }
+  if (params.cliEnvMode) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      envMode: params.cliEnvMode as CliEnvMode,
+    };
+  }
+  if (params.cliAllowCommands) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      allowCommands: params.cliAllowCommands.split(",").filter(Boolean),
+    };
+  }
+  if (params.cliDenyCommands) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      denyCommands: params.cliDenyCommands.split(",").filter(Boolean),
+    };
+  }
+  if (params.cliAllowCwdPrefixes) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      allowCwdPrefixes: params.cliAllowCwdPrefixes.split(",").filter(Boolean),
+    };
+  }
+  if (params.cliEnvAllowlist) {
+    opts.cli = {
+      ...(opts.cli ?? {}),
+      envAllowlist: params.cliEnvAllowlist.split(",").filter(Boolean),
+    };
+  }
+
+  return createBashJustPlugin(opts);
+}
+
+export default createBashJustPlugin;

--- a/packages/plugin-bash-just/tests/bash_just.test.ts
+++ b/packages/plugin-bash-just/tests/bash_just.test.ts
@@ -1,0 +1,210 @@
+/**
+ * E2E tests for plugin-bash-just
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { mcpc } from "@mcpc/core";
+import { createBashJustPlugin } from "../mod.ts";
+
+const AGENT_NAME = "agent";
+const TOOL_NAME = `${AGENT_NAME}__bash_just`;
+
+function makeServer(
+  pluginOpts: Parameters<typeof createBashJustPlugin>[0] = {},
+) {
+  return mcpc(
+    [{ name: "test-bash-just", version: "0.0.1" }, {
+      capabilities: { tools: {} },
+    }],
+    [{
+      name: AGENT_NAME,
+      description: "Test agent",
+      deps: { mcpServers: {} },
+      plugins: [createBashJustPlugin(pluginOpts)],
+    }],
+  );
+}
+
+async function createScript(body: string) {
+  const dir = await Deno.makeTempDir({ prefix: "bash-just-cli-" });
+  const scriptPath = `${dir}/tool.sh`;
+  await Deno.writeTextFile(
+    scriptPath,
+    `#!/usr/bin/env bash
+set -eu
+${body}
+`,
+  );
+  await Deno.chmod(scriptPath, 0o755);
+  return { dir, scriptPath };
+}
+
+// deno-lint-ignore no-explicit-any
+function callTool(server: any, args: Record<string, unknown>) {
+  return server.callTool(TOOL_NAME, args);
+}
+
+Deno.test("bash_just — interpreter mode still executes just-bash commands", async () => {
+  const server = await makeServer({
+    env: { GREETING: "world" },
+    initialFiles: { "/workspace/message.txt": "hello from memory" },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, {
+      command: "echo $GREETING && cat /workspace/message.txt",
+    });
+    assertEquals(r.isError, undefined);
+    assertStringIncludes(r.content[0].text, "world");
+    assertStringIncludes(r.content[0].text, "hello from memory");
+  } finally {
+    await server.close?.();
+  }
+});
+
+Deno.test("bash_just — real CLI mode executes a custom script", async () => {
+  const { dir, scriptPath } = await createScript(
+    'printf "custom:%s:%s\\n" "$1" "${MY_VAR:-missing}"',
+  );
+  const server = await makeServer({
+    env: { MY_VAR: "hello" },
+    cli: {
+      enabled: true,
+      allowCommands: [scriptPath],
+      envMode: "empty",
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, {
+      binary: scriptPath,
+      args: ["world"],
+    });
+    assertEquals(r.isError, undefined);
+    assertStringIncludes(r.content[0].text, "custom:world:hello");
+  } finally {
+    await server.close?.();
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("bash_just — denied binary is blocked by policy", async () => {
+  const server = await makeServer({
+    cli: {
+      enabled: true,
+      denyCommands: ["whoami"],
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, { binary: "whoami", args: [] });
+    assertEquals(r.isError, true);
+    assertStringIncludes(r.content[0].text, "DENIED");
+  } finally {
+    await server.close?.();
+  }
+});
+
+Deno.test("bash_just — argument policy is enforced for real CLI", async () => {
+  const { dir, scriptPath } = await createScript(
+    'printf "arg:%s\\n" "$1"',
+  );
+  const server = await makeServer({
+    cli: {
+      enabled: true,
+      allowCommands: [scriptPath],
+      allowArgs: {
+        [scriptPath]: [["--ok"]],
+      },
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, {
+      binary: scriptPath,
+      args: ["--blocked"],
+    });
+    assertEquals(r.isError, true);
+    assertStringIncludes(r.content[0].text, "DENIED");
+  } finally {
+    await server.close?.();
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("bash_just — cwd policy is enforced for real CLI", async () => {
+  const { dir, scriptPath } = await createScript("pwd");
+  const allowedDir = await Deno.makeTempDir({ prefix: "bash-just-allowed-" });
+  const blockedDir = await Deno.makeTempDir({ prefix: "bash-just-blocked-" });
+  const server = await makeServer({
+    cli: {
+      enabled: true,
+      allowCommands: [scriptPath],
+      allowCwdPrefixes: [allowedDir],
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, {
+      binary: scriptPath,
+      cwd: blockedDir,
+    });
+    assertEquals(r.isError, true);
+    assertStringIncludes(r.content[0].text, "DENIED");
+  } finally {
+    await server.close?.();
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+    await Deno.remove(allowedDir, { recursive: true }).catch(() => {});
+    await Deno.remove(blockedDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("bash_just — env allowlist is enforced for real CLI", async () => {
+  const { dir, scriptPath } = await createScript(
+    'printf "visible:%s secret:%s\\n" "${VISIBLE:-missing}" "${HOST_SECRET:-missing}"',
+  );
+  const originalVisible = Deno.env.get("VISIBLE");
+  const originalHostSecret = Deno.env.get("HOST_SECRET");
+  Deno.env.set("VISIBLE", "from-host");
+  Deno.env.set("HOST_SECRET", "should-not-leak");
+  const server = await makeServer({
+    cli: {
+      enabled: true,
+      allowCommands: [scriptPath],
+      envMode: "allowlist",
+      envAllowlist: ["VISIBLE"],
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, { binary: scriptPath });
+    assertEquals(r.isError, undefined);
+    assertStringIncludes(r.content[0].text, "visible:from-host");
+    assertStringIncludes(r.content[0].text, "secret:missing");
+  } finally {
+    Deno.env.set("VISIBLE", originalVisible ?? "");
+    Deno.env.set("HOST_SECRET", originalHostSecret ?? "");
+    await server.close?.();
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("bash_just — real CLI timeout is enforced", async () => {
+  const { dir, scriptPath } = await createScript("exec sleep 2");
+  const server = await makeServer({
+    timeoutMs: 200,
+    cli: {
+      enabled: true,
+      allowCommands: [scriptPath],
+    },
+  });
+  try {
+    // deno-lint-ignore no-explicit-any
+    const r: any = await callTool(server, { binary: scriptPath });
+    assertEquals(r.isError, true);
+    assertStringIncludes(r.content[0].text, "TIMEOUT");
+  } finally {
+    await server.close?.();
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary
- add core bash sandbox support with e2e coverage
- add plugin-bash-just for just-bash plus policy-controlled real CLI execution
- add plugin-bash-exec for secure-exec mediated CLI execution with policy controls

## Validation
- deno test --allow-all packages/core/tests/plugins/bash_plugin_test.ts packages/plugin-bash-just/tests/ packages/plugin-bash-exec/tests/
- deno task build
