### PR TITLE
Fix ACP tool error result payloads

### DIFF
--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -1194,16 +1194,22 @@ export class ACPLanguageModel implements LanguageModelV3 {
           break;
         }
 
+        const result = isError
+          ? {
+            error: formatToolError(toolResult),
+            toolResult: toolResult as any,
+          }
+          : toolResult as any;
+
         // Send the tool result (for server-side tools)
         controller.enqueue({
           type: "tool-result",
           toolCallId,
           toolName: ACP_PROVIDER_AGENT_DYNAMIC_TOOL_NAME,
-          result: toolResult as any,
+          result,
           // https://github.com/vercel/ai/blob/282f062922cb59167dd3a11e3af67cfa0b75f317/packages/ai/src/generate-text/run-tools-transformation.ts#L316
           ...(isError && {
             isError: true,
-            result: new Error(formatToolError(toolResult)),
           }),
         });
 

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -180,9 +180,11 @@ Deno.test("ACPLanguageModel - maps ACP stop reasons to AI SDK finish reasons", a
       request: unknown,
     ) => Promise<{ stopReason: string }>;
   }).promptWithLazyAuthRetry = () =>
-    Promise.resolve(promptResponses[responseIndex++] as {
-      stopReason: string;
-    });
+    Promise.resolve(
+      promptResponses[responseIndex++] as {
+        stopReason: string;
+      },
+    );
 
   (model as unknown as { cleanup: () => void }).cleanup = () => {};
 
@@ -203,4 +205,65 @@ Deno.test("ACPLanguageModel - maps ACP stop reasons to AI SDK finish reasons", a
     "other",
     "other",
   ]);
+});
+
+Deno.test("ACPLanguageModel - emits JSON-serializable tool error results", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const parts: unknown[] = [];
+  const toolOutput = [
+    {
+      type: "content",
+      content: { type: "text", text: "permission denied" },
+    },
+  ];
+
+  const stream = new ReadableStream({
+    start(controller) {
+      (model as unknown as {
+        handleStreamNotification: (
+          controller: ReadableStreamDefaultController<unknown>,
+          notification: unknown,
+        ) => void;
+      }).handleStreamNotification(controller, {
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          title: "read_file",
+          status: "failed",
+          rawInput: { path: "/tmp/secret.txt" },
+          rawOutput: toolOutput,
+          content: [],
+        },
+      });
+      controller.close();
+    },
+  });
+
+  for await (const part of stream) {
+    parts.push(part);
+  }
+
+  const toolResult = parts.find((part) =>
+    typeof part === "object" &&
+    part !== null &&
+    (part as { type?: string }).type === "tool-result"
+  ) as {
+    isError?: boolean;
+    result: unknown;
+  } | undefined;
+
+  assertExists(toolResult);
+  assertEquals(toolResult.isError, true);
+  assertEquals(toolResult.result, {
+    error: "permission denied",
+    toolResult: toolOutput,
+  });
+  assertEquals(
+    JSON.parse(JSON.stringify(toolResult.result)),
+    toolResult.result,
+  );
 });


### PR DESCRIPTION
## Summary

- Keep provider-executed ACP tool errors marked with `isError: true`.
- Replace the `Error` instance in `tool-result.result` with a plain JSON payload containing the formatted error and original tool output.
- Add a regression test that verifies failed tool updates emit a JSON-serializable result.

## Why

`LanguageModelV3ToolResult.result` is required to be JSON-serializable. Emitting an `Error` instance can lose the message when serialized, commonly becoming `{}`, which makes failed server-side tool results harder to inspect downstream.

## Validation

- `npm exec --yes deno@^2 -- test --allow-all tests/`
- `npm exec --yes deno@^2 -- lint packages/acp-ai-provider/src/language-model.ts packages/acp-ai-provider/tests/language-model.test.ts`
- `npm exec --yes deno@^2 -- check packages/acp-ai-provider/mod.ts`
- `npm exec --yes deno@^2 -- fmt --check packages/acp-ai-provider/src/language-model.ts packages/acp-ai-provider/tests/language-model.test.ts`