### PR TITLE
feat(acp-ai-provider): support abortSignal with session/cancel and turn serialization

### DIFF
--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -56,6 +56,28 @@ type ACPJsonRpcError = {
 
 type ACPPromptResponse = Awaited<ReturnType<ClientSideConnection["prompt"]>>;
 
+/**
+ * How long to wait for an aborted ACP turn to drain (i.e. for the original
+ * `session/prompt` to respond with `StopReason::Cancelled`) before giving up.
+ * Some agents may not honor `session/cancel`; without a bound the consumer's
+ * `ReadableStream.cancel()` could hang forever.
+ */
+const CANCEL_DRAIN_TIMEOUT_MS = 30_000;
+
+/**
+ * Races a promise against a timeout, clearing the timer once one of them
+ * settles so no dangling timer is left behind.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 function getACPResponse(response: ACPPromptResponse) {
   return {
     acp: JSON.parse(JSON.stringify(response)),
@@ -214,6 +236,10 @@ export class ACPLanguageModel implements LanguageModelV3 {
   private currentModeId: string | null = null;
   private isFreshSession = true;
 
+  // Serializes prompt turns across doStream/doGenerate calls. A new turn only
+  // starts after the previous one has fully drained (e.g. after abort/cancel).
+  private activeTurn: Promise<void> = Promise.resolve();
+
   // Captured stderr output from the agent process.
   private stderrChunks: string[] = [];
 
@@ -265,6 +291,27 @@ export class ACPLanguageModel implements LanguageModelV3 {
     this.currentThinkingId = null; // Added this line to match state
     this.toolCallsMap.clear();
     this.clientToolAbort = null;
+  }
+
+  /**
+   * Claims the model's single active-turn slot.
+   *
+   * Must be called synchronously before the first `await` of any
+   * turn-producing method so that concurrent calls are serialized even when
+   * they enter in the same tick. Returns a promise to wait for the previous
+   * turn to drain and a function that marks the current turn as finished.
+   */
+  private beginTurn(): {
+    waitForPrevious: Promise<void>;
+    finishTurn: () => void;
+  } {
+    let finishTurn!: () => void;
+    const turnDone = new Promise<void>((resolve) => {
+      finishTurn = resolve;
+    });
+    const waitForPrevious = this.activeTurn;
+    this.activeTurn = turnDone;
+    return { waitForPrevious, finishTurn };
   }
 
   private hasToolInput(input: unknown): boolean {
@@ -1222,6 +1269,11 @@ export class ACPLanguageModel implements LanguageModelV3 {
   async doGenerate(
     options: LanguageModelV3CallOptions,
   ): Promise<LanguageModelV3GenerateResult> {
+    // Serialize with streaming turns so a new prompt is only issued after the
+    // previous turn has fully drained.
+    const { waitForPrevious, finishTurn } = this.beginTurn();
+    await waitForPrevious.catch(() => {});
+
     try {
       // Build JSON schema prompt if responseFormat requests JSON output
       const jsonResponseFormat = isJsonResponseFormat(options.responseFormat)
@@ -1377,6 +1429,8 @@ export class ACPLanguageModel implements LanguageModelV3 {
     } catch (error) {
       this.cleanup();
       throw error;
+    } finally {
+      finishTurn();
     }
   }
 
@@ -1387,137 +1441,213 @@ export class ACPLanguageModel implements LanguageModelV3 {
     stream: ReadableStream<LanguageModelV3StreamPart>;
     warnings: undefined;
   }> {
-    // IMPORTANT: Extract and register ACP tools BEFORE ensureConnected
-    // This ensures Tool Proxy can discover them when it starts
-    const acpTools = extractACPTools(options.tools);
+    // Claim the active-turn slot BEFORE any await. This serializes prompt
+    // turns: a new prompt is only issued after the previous turn has fully
+    // drained (e.g. an aborted turn has responded with `cancelled`).
+    const { waitForPrevious, finishTurn } = this.beginTurn();
+    await waitForPrevious.catch(() => {});
 
-    // Detect JSON output mode and build schema prompt if needed
-    const jsonResponseFormat = isJsonResponseFormat(options.responseFormat)
-      ? options.responseFormat
-      : null;
-    const jsonSchemaPrompt = jsonResponseFormat
-      ? buildJsonSchemaPrompt(jsonResponseFormat)
-      : undefined;
-
-    // Now connect with the registered tools
     try {
+      // IMPORTANT: Extract and register ACP tools BEFORE ensureConnected
+      // This ensures Tool Proxy can discover them when it starts
+      const acpTools = extractACPTools(options.tools);
+
+      // Detect JSON output mode and build schema prompt if needed
+      const jsonResponseFormat = isJsonResponseFormat(options.responseFormat)
+        ? options.responseFormat
+        : null;
+      const jsonSchemaPrompt = jsonResponseFormat
+        ? buildJsonSchemaPrompt(jsonResponseFormat)
+        : undefined;
+
+      // Now connect with the registered tools
       await this.ensureConnected(acpTools.length > 0 ? acpTools : undefined);
+
+      /*
+        If we just created the session (isFreshSession=true), we send full prompt.
+        If we reused it, we send filtered prompt.
+        After sending, we are no longer "fresh" for subsequent calls on this instance.
+      */
+      const promptContent = convertAiSdkMessagesToAcp(
+        options,
+        this.isFreshSession,
+        jsonSchemaPrompt,
+      );
+      this.isFreshSession = false;
+
+      const sessionId = this.sessionId!;
+      const client = this.client;
+      const connection = this.connection;
+      const cleanup = () => this.cleanup();
+
+      // Get a reference to the bound method
+      const streamHandler = this.handleStreamNotification.bind(this);
+
+      let cancelRequested = false;
+      let consumerCancelled = false;
+      let controllerClosed = false;
+      let promptSettled: Promise<void> = Promise.resolve();
+
+      // Sends session/cancel exactly once. This only notifies the agent; the
+      // turn is truly over when the original prompt settles (with `cancelled`).
+      const cancelTurn = async () => {
+        if (cancelRequested) return;
+        cancelRequested = true;
+        try {
+          await connection?.cancel({ sessionId });
+        } catch {
+          // Best effort: the connection may already be gone.
+        }
+      };
+
+      const onAbort = () => {
+        void cancelTurn();
+      };
+
+      if (!options.abortSignal?.aborted) {
+        options.abortSignal?.addEventListener("abort", onAbort, { once: true });
+      }
+
+      const stream = new ReadableStream<LanguageModelV3StreamPart>({
+        start: async (
+          controller: ReadableStreamDefaultController<
+            LanguageModelV3StreamPart
+          >,
+        ) => {
+          try {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+
+            // Reset stream state for this new stream
+            this.resetStreamState();
+
+            if (options.abortSignal?.aborted) {
+              // Aborted before the prompt was issued: nothing to cancel, just
+              // end the turn and close the empty stream.
+              controllerClosed = true;
+              controller.close();
+              return;
+            }
+
+            // Set up client tool abort mechanism
+            const clientToolPromise = new Promise<void>((resolve) => {
+              this.clientToolAbort = { controller, resolve };
+            });
+
+            if (client) {
+              client.setSessionUpdateHandler(
+                (notification: SessionNotification) => {
+                  // Drop stale notifications once the consumer cancelled or the
+                  // controller is closed (abort/cancel drain, or the client-tool
+                  // abort path closing the stream itself).
+                  if (consumerCancelled || controllerClosed) return;
+                  if (controller.desiredSize === null) {
+                    controllerClosed = true;
+                    return;
+                  }
+                  // Call the centralized handler
+                  streamHandler(controller, notification);
+                },
+              );
+            }
+
+            // Race between normal completion and client tool abort
+            const promptPromise = this.promptWithLazyAuthRetry({
+              sessionId,
+              prompt: promptContent,
+            });
+            promptSettled = promptPromise.then(
+              () => undefined,
+              () => undefined,
+            );
+
+            const result = await Promise.race([
+              promptPromise.then((response) => ({
+                type: "response" as const,
+                response,
+              })),
+              clientToolPromise.then(() => ({ type: "client-tool" as const })),
+            ]);
+
+            // If client tool was detected, stream is already closed
+            if (result.type === "client-tool") {
+              return;
+            }
+
+            // Nothing left to emit if the consumer cancelled the stream or the
+            // controller was closed while draining.
+            if (consumerCancelled || controllerClosed) {
+              return;
+            }
+
+            // Normal completion
+            const response = result.response;
+            controller.enqueue({
+              type: "finish",
+              finishReason: {
+                unified: mapACPStopReasonToAISDK(response.stopReason),
+                raw: response.stopReason,
+              },
+              providerMetadata: getACPResponse(response),
+              usage: {
+                inputTokens: {
+                  total: undefined,
+                  noCache: undefined,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: undefined,
+                  text: undefined,
+                  reasoning: undefined,
+                },
+              },
+            });
+            controllerClosed = true;
+            controller.close();
+          } catch (error) {
+            if (!consumerCancelled && !controllerClosed) {
+              controller.enqueue({
+                type: "error",
+                error: toCatchableError(error, this.stderrChunks.join("")),
+              });
+            }
+          } finally {
+            options.abortSignal?.removeEventListener("abort", onAbort);
+            finishTurn();
+            cleanup();
+          }
+        },
+        cancel: async () => {
+          consumerCancelled = true;
+          try {
+            await cancelTurn();
+            // Wait for the original prompt to settle (normally with
+            // `cancelled`) instead of only waiting for the cancel notification
+            // to be written. Bound the drain so a misbehaving agent cannot hang
+            // the consumer's cancel() forever.
+            await withTimeout(promptSettled, CANCEL_DRAIN_TIMEOUT_MS);
+          } finally {
+            cleanup();
+          }
+        },
+      });
+
+      // In structured JSON mode, wrap the stream with a transform that strips
+      // markdown fences from text content (models sometimes wrap JSON in ```json blocks
+      // despite being instructed not to).
+      const outputStream = jsonResponseFormat
+        ? stream.pipeThrough(createJsonCleanupTransform())
+        : stream;
+
+      return { stream: outputStream, warnings: undefined };
     } catch (error) {
-      // If connection/session setup fails before stream starts,
-      // ensure child process does not keep the event loop alive.
+      // If connection/session setup fails before the stream starts, ensure the
+      // child process does not keep the event loop alive and release the
+      // active-turn slot.
+      finishTurn();
       this.forceCleanup();
       throw error;
     }
-
-    /*
-      If we just created the session (isFreshSession=true), we send full prompt.
-      If we reused it, we send filtered prompt.
-      After sending, we are no longer "fresh" for subsequent calls on this instance.
-    */
-    const promptContent = convertAiSdkMessagesToAcp(
-      options,
-      this.isFreshSession,
-      jsonSchemaPrompt,
-    );
-    this.isFreshSession = false;
-
-    const sessionId = this.sessionId!;
-    const client = this.client;
-    const cleanup = () => this.cleanup();
-
-    // Get a reference to the bound method
-    const streamHandler = this.handleStreamNotification.bind(this);
-
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
-      start: async (
-        controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
-      ) => {
-        controller.enqueue({ type: "stream-start", warnings: [] });
-
-        // Reset stream state for this new stream
-        this.resetStreamState();
-
-        // Set up client tool abort mechanism
-        const clientToolPromise = new Promise<void>((resolve) => {
-          this.clientToolAbort = { controller, resolve };
-        });
-
-        try {
-          if (client) {
-            client.setSessionUpdateHandler(
-              (notification: SessionNotification) => {
-                // Call the centralized handler
-                streamHandler(controller, notification);
-              },
-            );
-          }
-
-          // Race between normal completion and client tool abort
-          const promptPromise = this.promptWithLazyAuthRetry({
-            sessionId,
-            prompt: promptContent,
-          });
-
-          const result = await Promise.race([
-            promptPromise.then((response) => ({
-              type: "response" as const,
-              response,
-            })),
-            clientToolPromise.then(() => ({ type: "client-tool" as const })),
-          ]);
-
-          // If client tool was detected, stream is already closed
-          if (result.type === "client-tool") {
-            return;
-          }
-
-          // Normal completion
-          const response = result.response;
-          controller.enqueue({
-            type: "finish",
-            finishReason: {
-              unified: mapACPStopReasonToAISDK(response.stopReason),
-              raw: response.stopReason,
-            },
-            providerMetadata: getACPResponse(response),
-            usage: {
-              inputTokens: {
-                total: undefined,
-                noCache: undefined,
-                cacheRead: undefined,
-                cacheWrite: undefined,
-              },
-              outputTokens: {
-                total: undefined,
-                text: undefined,
-                reasoning: undefined,
-              },
-            },
-          });
-
-          controller.close();
-          cleanup();
-        } catch (error) {
-          cleanup();
-          controller.enqueue({
-            type: "error",
-            error: toCatchableError(error, this.stderrChunks.join("")),
-          });
-        }
-      },
-      cancel: () => {
-        cleanup();
-      },
-    });
-
-    // In structured JSON mode, wrap the stream with a transform that strips
-    // markdown fences from text content (models sometimes wrap JSON in ```json blocks
-    // despite being instructed not to).
-    const outputStream = jsonResponseFormat
-      ? stream.pipeThrough(createJsonCleanupTransform())
-      : stream;
-
-    return { stream: outputStream, warnings: undefined };
   }
 
   get tools(): Record<string, ReturnType<typeof tool>> {

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -36,113 +36,6 @@ Deno.test("ACPLanguageModel - implements LanguageModelV3 interface", () => {
   assertEquals(typeof model.doStream, "function");
 });
 
-Deno.test("ACPLanguageModel - config is stored from constructor", () => {
-  const config = createProviderSettings({
-    command: "custom-agent",
-    args: ["--flag1", "--flag2"],
-    env: { API_KEY: "secret123" },
-  });
-
-  const model = new ACPLanguageModel("agent", undefined, config);
-
-  // Model should have the config stored (accessed via language-model behavior)
-  assertExists(model);
-  assertEquals(model.modelId, "agent");
-});
-
-Deno.test("ACPLanguageModel - handles optional initialize config", () => {
-  // Without initialize config
-  const config1 = createProviderSettings();
-  const model1 = new ACPLanguageModel("agent1", undefined, config1);
-  assertExists(model1);
-
-  // With initialize config
-  const config2 = createProviderSettings({
-    initialize: {
-      protocolVersion: 1,
-      clientCapabilities: {
-        fs: { readTextFile: true, writeTextFile: false },
-        terminal: false,
-      },
-    },
-  });
-  const model2 = new ACPLanguageModel("agent2", undefined, config2);
-  assertExists(model2);
-});
-
-Deno.test("ACPLanguageModel - preserves command and args in config", () => {
-  const command = "my-custom-agent";
-  const args = ["--mode", "production", "--verbose"];
-  const config = createProviderSettings({ command, args });
-
-  const model = new ACPLanguageModel("test", undefined, config);
-
-  // Verify model creation didn't lose the config
-  assertExists(model);
-  assertEquals(model.modelId, "test");
-});
-
-Deno.test("ACPLanguageModel - handles environment variables in config", () => {
-  const env = {
-    API_KEY: "test-key",
-    DEBUG: "true",
-    CUSTOM_VAR: "custom-value",
-  };
-
-  const config = createProviderSettings({ env });
-  const model = new ACPLanguageModel("agent-with-env", undefined, config);
-
-  assertExists(model);
-  assertEquals(model.modelId, "agent-with-env");
-});
-
-Deno.test("ACPLanguageModel - supports different agent commands", () => {
-  const commands = [
-    { cmd: "gemini", args: ["--experimental-acp"] },
-    { cmd: "claude-code", args: ["--acp"] },
-    { cmd: "npx", args: ["-y", "tsx", "./agent.ts"] },
-    { cmd: "node", args: ["agent.mjs"] },
-  ];
-
-  for (const { cmd, args } of commands) {
-    const model = new ACPLanguageModel(
-      "agent",
-      undefined,
-      createProviderSettings({ command: cmd, args }),
-    );
-    assertExists(model);
-    assertEquals(model.provider, "acp");
-  }
-});
-
-Deno.test("ACPLanguageModel - session config is required", () => {
-  // Session is required, so providing a valid one should work
-  const config = createProviderSettings({
-    session: {
-      cwd: "/workspace",
-      mcpServers: [],
-    },
-  });
-
-  const model = new ACPLanguageModel("agent", undefined, config);
-  assertExists(model);
-});
-
-Deno.test("ACPLanguageModel - model properties are consistent", () => {
-  const modelId = "my-model-123";
-  const model = new ACPLanguageModel(
-    modelId,
-    undefined,
-    createProviderSettings(),
-  );
-
-  // Properties should be consistent across multiple accesses
-  assertEquals(model.modelId, modelId);
-  assertEquals(model.modelId, "my-model-123");
-  assertEquals(model.provider, "acp");
-  assertEquals(model.specificationVersion, "v3");
-});
-
 Deno.test("ACPLanguageModel - maps ACP stop reasons to AI SDK finish reasons", async () => {
   const model = new ACPLanguageModel(
     "test-agent",
@@ -205,4 +98,279 @@ Deno.test("ACPLanguageModel - maps ACP stop reasons to AI SDK finish reasons", a
     "other",
     "other",
   ]);
+});
+
+/**
+ * Helpers for abort/cancel tests: stubs the ACP internals so we can drive
+ * prompt resolution and observe session/cancel + prompt ordering.
+ */
+function setupMockModel() {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+
+  const events: string[] = [];
+  const promptDeferreds: Array<{
+    resolve: (value: { stopReason: string }) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  const promptRequests: Array<{ sessionId: string }> = [];
+  let promptCount = 0;
+  let cancelCount = 0;
+  let updateHandler: ((notification: unknown) => void) | null = null;
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { connection: unknown }).connection = {
+    cancel: () => {
+      cancelCount++;
+      events.push("cancel");
+    },
+  };
+  (model as unknown as { client: unknown }).client = {
+    setSessionUpdateHandler: (handler: (notification: unknown) => void) => {
+      updateHandler = handler;
+    },
+  };
+  (model as unknown as { ensureConnected: () => void })
+    .ensureConnected = () => {
+      events.push("connect");
+    };
+  (model as unknown as {
+    promptWithLazyAuthRetry: (request: {
+      sessionId: string;
+      prompt: unknown;
+    }) => Promise<{ stopReason: string }>;
+  }).promptWithLazyAuthRetry = (request: {
+    sessionId: string;
+    prompt: unknown;
+  }) => {
+    promptCount++;
+    promptRequests.push(request);
+    events.push("prompt");
+    return new Promise<{ stopReason: string }>((resolve, reject) => {
+      promptDeferreds.push({ resolve, reject });
+    });
+  };
+  (model as unknown as { cleanup: () => void }).cleanup = () => {};
+
+  return {
+    model,
+    events,
+    promptDeferreds,
+    promptRequests,
+    promptCount: () => promptCount,
+    cancelCount: () => cancelCount,
+    updateHandler: () => updateHandler,
+  };
+}
+
+async function readAll(stream: ReadableStream<unknown>): Promise<unknown[]> {
+  const reader = stream.getReader();
+  const parts: unknown[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  return parts;
+}
+
+async function readNext(
+  reader: ReadableStreamDefaultReader<any>,
+): Promise<any> {
+  const { done, value } = await reader.read();
+  assertEquals(done, false);
+  return value;
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const basicOptions = {
+  prompt: [{ role: "user" as const, content: "hello" }],
+};
+
+Deno.test("doStream - normal stream is unaffected by abort handling", async () => {
+  const h = setupMockModel();
+  const { stream } = await h.model.doStream(basicOptions as never);
+
+  h.promptDeferreds[0].resolve({ stopReason: "end_turn" });
+  const parts = await readAll(stream);
+
+  assertEquals(h.promptCount(), 1);
+  assertEquals(h.cancelCount(), 0);
+  const finish = parts.find((p) => (p as { type: string }).type === "finish");
+  assertExists(finish);
+  assertEquals(
+    (finish as { finishReason: { raw: string } }).finishReason.raw,
+    "end_turn",
+  );
+});
+
+Deno.test("doStream - abort during output sends session/cancel once and ends with cancelled", async () => {
+  const h = setupMockModel();
+  const controller = new AbortController();
+  const { stream } = await h.model.doStream({
+    ...basicOptions,
+    abortSignal: controller.signal,
+  } as never);
+
+  const reader = stream.getReader();
+  assertEquals(await readNext(reader), {
+    type: "stream-start",
+    warnings: [],
+  });
+
+  controller.abort();
+  await tick();
+
+  assertEquals(h.cancelCount(), 1);
+  assertEquals(h.events, ["connect", "prompt", "cancel"]);
+
+  h.promptDeferreds[0].resolve({ stopReason: "cancelled" });
+  const finish = await readNext(reader);
+  assertEquals(finish.type, "finish");
+  assertEquals(finish.finishReason.raw, "cancelled");
+  assertEquals((await reader.read()).done, true);
+});
+
+Deno.test("doStream - abort while prompt is in flight (tool execution) still drains cleanly", async () => {
+  const h = setupMockModel();
+  const controller = new AbortController();
+  const { stream } = await h.model.doStream({
+    ...basicOptions,
+    abortSignal: controller.signal,
+  } as never);
+
+  const reader = stream.getReader();
+  await reader.read(); // stream-start
+
+  // Abort while the agent is still working (e.g. running a tool).
+  controller.abort();
+  await tick();
+  assertEquals(h.cancelCount(), 1);
+
+  // The original prompt eventually responds with `cancelled`.
+  h.promptDeferreds[0].resolve({ stopReason: "cancelled" });
+  assertEquals((await readNext(reader)).type, "finish");
+  assertEquals((await reader.read()).done, true);
+});
+
+Deno.test("doStream - aborted turn fully drains before the next prompt is issued", async () => {
+  const h = setupMockModel();
+  const controller = new AbortController();
+
+  const streamPromise1 = h.model.doStream({
+    ...basicOptions,
+    abortSignal: controller.signal,
+  } as never);
+  const { stream: stream1 } = await streamPromise1;
+  const reader1 = stream1.getReader();
+  await reader1.read(); // stream-start
+
+  controller.abort();
+  await tick();
+  assertEquals(h.cancelCount(), 1);
+
+  // Kick off the second turn while the first is still draining.
+  const streamPromise2 = h.model.doStream(basicOptions as never);
+  await tick();
+
+  // The second prompt must NOT be issued before the first turn settles.
+  assertEquals(h.promptCount(), 1);
+
+  h.promptDeferreds[0].resolve({ stopReason: "cancelled" });
+
+  const { stream: stream2 } = await streamPromise2;
+  assertEquals(h.promptCount(), 2);
+  assertEquals(h.promptRequests[0].sessionId, "session-1");
+  assertEquals(h.promptRequests[1].sessionId, "session-1");
+  // Acceptance order: prompt#1 -> cancel -> prompt#1 settles -> prompt#2.
+  assertEquals(h.events, ["connect", "prompt", "cancel", "connect", "prompt"]);
+
+  h.promptDeferreds[1].resolve({ stopReason: "end_turn" });
+  const parts2 = await readAll(stream2);
+  const finish2 = parts2.find((p) => (p as { type: string }).type === "finish");
+  assertExists(finish2);
+  assertEquals(
+    (finish2 as { finishReason: { raw: string } }).finishReason.raw,
+    "end_turn",
+  );
+
+  // First stream also terminates cleanly with `cancelled`.
+  assertEquals((await readNext(reader1)).type, "finish");
+  assertEquals((await reader1.read()).done, true);
+});
+
+Deno.test("doStream - stale session/update after close is dropped without throwing", async () => {
+  const h = setupMockModel();
+  const controller = new AbortController();
+  const { stream } = await h.model.doStream({
+    ...basicOptions,
+    abortSignal: controller.signal,
+  } as never);
+
+  const reader = stream.getReader();
+  await reader.read(); // stream-start
+
+  // Updates while the stream is open still flow through.
+  h.updateHandler()!({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "hi" },
+    },
+  } as never);
+  assertEquals((await readNext(reader)).type, "text-start");
+  assertEquals((await readNext(reader)).type, "text-delta");
+
+  controller.abort();
+  await tick();
+  h.promptDeferreds[0].resolve({ stopReason: "cancelled" });
+  assertEquals((await readNext(reader)).type, "finish");
+  assertEquals((await reader.read()).done, true);
+
+  // A late notification from the old turn must not write to the closed
+  // controller (no "Controller is already closed").
+  h.updateHandler()!({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "late" },
+    },
+  } as never);
+  assertEquals(h.cancelCount(), 1);
+});
+
+Deno.test("doStream - consumer cancel() sends ACP cancel and waits for the turn to drain", async () => {
+  const h = setupMockModel();
+  const { stream } = await h.model.doStream(basicOptions as never);
+
+  const reader = stream.getReader();
+  await reader.read(); // stream-start
+
+  const cancelPromise = reader.cancel();
+  await tick();
+  assertEquals(h.cancelCount(), 1);
+
+  h.promptDeferreds[0].resolve({ stopReason: "cancelled" });
+  await cancelPromise;
+});
+
+Deno.test("doStream - pre-aborted signal skips prompt and cancel entirely", async () => {
+  const h = setupMockModel();
+  const controller = new AbortController();
+  controller.abort();
+
+  const { stream } = await h.model.doStream({
+    ...basicOptions,
+    abortSignal: controller.signal,
+  } as never);
+
+  const parts = await readAll(stream);
+  assertEquals(parts.length, 1);
+  assertEquals((parts[0] as { type: string }).type, "stream-start");
+  assertEquals(h.promptCount(), 0);
+  assertEquals(h.cancelCount(), 0);
 });


### PR DESCRIPTION
## Motivation

`ACPLanguageModel.doStream` previously ignored `abortSignal` entirely: aborting did not stop the active turn, and the next `doStream` call could run concurrently with the old turn. Stale `session/update` notifications from the old turn were then written into an already-closed controller (`Invalid state: Controller is already closed`), and prompt ordering was not guaranteed.

Per the ACP protocol, `session/cancel` is only a notification; the old turn is truly over once the original `session/prompt` responds with `StopReason::Cancelled`. So turns must be serialized, and the client must keep accepting trailing updates after cancel.

## Changes

- **Abort → ACP cancel**: register an `abortSignal` listener (`once`, removed in `finally`) that sends `connection.cancel({ sessionId })`; `cancelRequested` guarantees exactly one notification. If the signal is already aborted, skip the prompt and cancel entirely and close an empty stream.
- **Turn serialization**: new `activeTurn` + `beginTurn()` claim the turn slot synchronously before any `await` (so concurrent calls in the same tick cannot bypass the barrier), covering `ensureConnected` as well. `doGenerate` participates in the same barrier.
- **`ReadableStream.cancel()` drains asynchronously**: set `consumerCancelled` → send ACP cancel → wait for the original prompt to settle (30s timeout fallback via `withTimeout`, which clears its timer) → cleanup.
- **Drop writes to a closed controller**: the `setSessionUpdateHandler` callback returns early when `consumerCancelled || controllerClosed`; a `controller.desiredSize === null` check also covers the client-tool path that closes the stream itself. `controllerClosed` is set before `controller.close()`, and the error path is guarded the same way.

## Tests

Added 7 `doStream` tests (stubbed ACP internals with controllable prompt resolution):

1. Normal stream unaffected
2. Abort during output: exactly one cancel, finish with `cancelled`
3. Abort while the prompt is in flight (e.g. tool execution) drains cleanly
4. After abort, the second prompt is issued only after the first turn settles (`prompt → cancel → prompt`, same session reused)
5. Stale `session/update` after close does not throw `Controller is already closed`
6. Consumer `cancel()` sends ACP cancel and waits for the turn to drain
7. Pre-aborted signal skips prompt and cancel

Also removed 7 constructor smoke tests that only asserted `modelId` or instance existence.

## Validation

- `deno test --allow-all tests/`: 15 passed
- `deno check` / `deno fmt --check` / `deno lint`: clean