### PR TITLE
fix(mcpc-builder): clear network check timer on all paths

### DIFF
--- a/packages/mcpc-builder/tests/builder_test.ts
+++ b/packages/mcpc-builder/tests/builder_test.ts
@@ -17,18 +17,19 @@ const TEST_SERVER = "io.github.wonderwhy-er/desktop-commander";
 
 // Helper to check if network is available
 async function isNetworkAvailable(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
     const resp = await fetch("https://mcpc.tech/health", {
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
     // Consume the response body to avoid leaks
     await resp.text();
     return true;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## Problem

`isNetworkAvailable()` in `builder_test.ts` only cleared its 5s timeout on the success path. When the `mcpc.tech/health` fetch failed (e.g. network unavailable), the timer stayed pending and Deno's leak detection failed every test that called it:

- Registry Client - Search servers / Get server details / Get server capabilities
- Config Builder - Compose simple MCP config / Compose MCPC config

```
error: Leaks detected:
  - A timer was started in this test, but never completed.
```

## Fix

Move `clearTimeout(timeoutId)` into a `finally` block so the timer is always cleared, on both success and failure paths.

## Validation

- `deno test --allow-all --trace-leaks packages/mcpc-builder/tests/builder_test.ts`: 9 passed, 0 failed