### PR TITLE
feat(acp-ai-provider): support session config options

### DIFF
--- a/packages/acp-ai-provider/README.md
+++ b/packages/acp-ai-provider/README.md
@@ -417,11 +417,12 @@ function cleanupSession(sessionId: string) {
 See [session-management-example.ts](./examples/session-management-example.ts)
 for a complete working example.
 
-### Selecting Models and Modes
+### Selecting Models, Modes, and Session Config Options
 
-Some ACP agents support multiple models or modes. Use `initSession()` to
-discover and select them (or simply provide an arbitrary value to get an error
-message listing available options):
+Some ACP agents support multiple models, modes, or general session config
+options. Use `initSession()` to discover what the current agent advertises.
+Config IDs and values are agent-defined, so do not assume that the same ID is
+used by every agent.
 
 ```typescript
 const provider = createACPProvider({
@@ -434,19 +435,45 @@ const provider = createACPProvider({
 // Initialize and get available options
 const session = await provider.initSession();
 
-// Check available modes (e.g., "default", "acceptEdits", "plan")
+// Existing model/mode APIs remain supported.
 console.log(session.modes?.availableModes);
-
-// Check available models (e.g. "default", "opus", "haiku")
 console.log(session.models?.availableModels);
+await provider.setMode("plan");
+await provider.setModel("opus");
 
-// Now use the model
+// Inspect arbitrary options advertised by this agent.
+console.log(session.configOptions);
+console.log(provider.getConfigOptions("thought_level"));
+
+// Set an option using its advertised ID and value.
+const option = session.configOptions?.find((item) =>
+  item.category === "thought_level"
+);
+if (option) {
+  await provider.setConfigOption(option.id, "high");
+}
+
+// Or resolve the option by semantic category without hard-coding its ID.
+await provider.setThoughtLevel("high");
+await provider.setConfigOptionByCategory("model_config", "balanced");
+
 const result = await generateText({
-  // You can optionally specify the model ID here
-  model: provider.languageModel("opus", "plan"),
+  model: provider.languageModel(),
   prompt: "...",
 });
 ```
+
+`setConfigOption()` returns the ACP `SetSessionConfigOptionResponse`. The
+provider caches its returned `configOptions`, because changing one option may
+change the available values or state of other options. `getConfigOptions()`
+therefore reflects the latest successful update for the provider's active
+session.
+
+`setConfigOptionByCategory()` and `setThoughtLevel()` only select an option when
+exactly one advertised option has that category. They throw when none or
+multiple match; in the multiple-match case, inspect `getConfigOptions(category)`
+and call `setConfigOption()` with the intended ID. Unknown custom categories are
+supported.
 
 ## FAQ
 

--- a/packages/acp-ai-provider/mod.ts
+++ b/packages/acp-ai-provider/mod.ts
@@ -41,9 +41,13 @@ export type { ProviderAgentDynamicToolInput } from "./src/language-model.ts";
 export type {
   ModelInfo,
   NewSessionResponse,
+  SessionConfigOption,
+  SessionConfigOptionCategory,
+  SessionConfigValueId,
   SessionMode,
   SessionModelState,
   SessionModeState,
+  SetSessionConfigOptionResponse,
 } from "@agentclientprotocol/sdk";
 
 // ACP Tool - for defining tools that work with streamText

--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -16,7 +16,11 @@ import {
   type ReadTextFileResponse,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
+  type SessionConfigOption,
+  type SessionConfigOptionCategory,
   type SessionNotification,
+  type SetSessionConfigOptionRequest,
+  type SetSessionConfigOptionResponse,
   type ToolCallContent,
   type ToolCallStatus,
   type WriteTextFileRequest,
@@ -770,6 +774,79 @@ export class ACPLanguageModel implements LanguageModelV3 {
     }
   }
 
+  /**
+   * Returns the session configuration options advertised by the agent.
+   * A category filters by the protocol's semantic category rather than an
+   * agent-specific config ID.
+   */
+  getConfigOptions(
+    category?: SessionConfigOptionCategory,
+  ): SessionConfigOption[] {
+    const configOptions = this.sessionResponse?.configOptions ?? [];
+    return category === undefined
+      ? [...configOptions]
+      : configOptions.filter((option) => option.category === category);
+  }
+
+  /**
+   * Sets an ACP session configuration option by its agent-advertised ID.
+   */
+  async setConfigOption(
+    configId: string,
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    if (!this.connection || !this.sessionId) {
+      throw new Error("Not connected. Call initSession() first.");
+    }
+
+    const response = await this.connection.setSessionConfigOption({
+      sessionId: this.sessionId,
+      configId,
+      value,
+    });
+
+    if (this.sessionResponse) {
+      this.sessionResponse = {
+        ...this.sessionResponse,
+        configOptions: response.configOptions,
+      };
+    }
+
+    return response;
+  }
+
+  /**
+   * Sets the single option advertised for a semantic category.
+   */
+  async setConfigOptionByCategory(
+    category: SessionConfigOptionCategory,
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    const matches = this.getConfigOptions(category);
+    if (matches.length === 0) {
+      throw new Error(
+        `No session config option is available for category "${category}".`,
+      );
+    }
+    if (matches.length > 1) {
+      const ids = matches.map((option) => option.id).join(", ");
+      throw new Error(
+        `Multiple session config options are available for category "${category}": ${ids}. Use setConfigOption() with an explicit config ID.`,
+      );
+    }
+
+    return await this.setConfigOption(matches[0].id, value);
+  }
+
+  /**
+   * Sets the option advertised with the standard `thought_level` category.
+   */
+  setThoughtLevel(
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    return this.setConfigOptionByCategory("thought_level", value);
+  }
+
   private async promptWithLazyAuthRetry(
     request: { sessionId: string; prompt: unknown },
   ): Promise<ACPPromptResponse> {
@@ -946,6 +1023,14 @@ export class ACPLanguageModel implements LanguageModelV3 {
 
     const update = notification.update;
     switch (update.sessionUpdate) {
+      case "config_option_update":
+        if (this.sessionResponse && notification.sessionId === this.sessionId) {
+          this.sessionResponse = {
+            ...this.sessionResponse,
+            configOptions: update.configOptions,
+          };
+        }
+        break;
       case "plan":
         this.flushPendingToolCalls(controller);
         this.emitRawContent(controller, {

--- a/packages/acp-ai-provider/src/provider.ts
+++ b/packages/acp-ai-provider/src/provider.ts
@@ -5,7 +5,13 @@
 import { ACPLanguageModel } from "./language-model.ts";
 import type { tool } from "ai";
 import type { ACPProviderSettings } from "./types.ts";
-import type { NewSessionResponse } from "@agentclientprotocol/sdk";
+import type {
+  NewSessionResponse,
+  SessionConfigOption,
+  SessionConfigOptionCategory,
+  SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse,
+} from "@agentclientprotocol/sdk";
 
 /**
  * ACP Provider - implements AI SDK provider pattern
@@ -123,6 +129,54 @@ export class ACPProvider {
       throw new Error("No model initialized. Call languageModel() first.");
     }
     return this.model.setModel(modelId);
+  }
+
+  /**
+   * Returns config options advertised by the active ACP session, optionally
+   * filtered by semantic category.
+   */
+  getConfigOptions(
+    category?: SessionConfigOptionCategory,
+  ): SessionConfigOption[] {
+    return this.model?.getConfigOptions(category) ?? [];
+  }
+
+  /**
+   * Sets any ACP session config option using its agent-advertised ID.
+   */
+  setConfigOption(
+    configId: string,
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    if (!this.model) {
+      throw new Error("No model initialized. Call initSession() first.");
+    }
+    return this.model.setConfigOption(configId, value);
+  }
+
+  /**
+   * Sets the single config option advertised for a semantic category.
+   */
+  setConfigOptionByCategory(
+    category: SessionConfigOptionCategory,
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    if (!this.model) {
+      throw new Error("No model initialized. Call initSession() first.");
+    }
+    return this.model.setConfigOptionByCategory(category, value);
+  }
+
+  /**
+   * Sets the option advertised with the standard `thought_level` category.
+   */
+  setThoughtLevel(
+    value: SetSessionConfigOptionRequest["value"],
+  ): Promise<SetSessionConfigOptionResponse> {
+    if (!this.model) {
+      throw new Error("No model initialized. Call initSession() first.");
+    }
+    return this.model.setThoughtLevel(value);
   }
 
   /**

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -2,7 +2,7 @@
  * Tests for ACP Language Model
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { ACPLanguageModel } from "../src/language-model.ts";
 import type { ACPProviderSettings } from "../src/types.ts";
 
@@ -98,6 +98,144 @@ Deno.test("ACPLanguageModel - maps ACP stop reasons to AI SDK finish reasons", a
     "other",
     "other",
   ]);
+});
+
+function setupConfigOptionModel() {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const requests: unknown[] = [];
+  const initialOptions = [
+    {
+      id: "agent-specific-reasoning-id",
+      name: "Thinking effort",
+      description: "Controls reasoning effort",
+      category: "thought_level",
+      type: "select" as const,
+      currentValue: "medium",
+      options: [
+        { value: "low", name: "Low" },
+        { value: "medium", name: "Medium" },
+        { value: "high", name: "High" },
+      ],
+    },
+    {
+      id: "agent-specific-style-id",
+      name: "Style",
+      category: "_style",
+      type: "select" as const,
+      currentValue: "concise",
+      options: [{ value: "concise", name: "Concise" }],
+    },
+  ];
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: initialOptions,
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: (request: unknown) => {
+      requests.push(request);
+      return Promise.resolve({
+        configOptions: [
+          { ...initialOptions[0], currentValue: "high" },
+          initialOptions[1],
+        ],
+      });
+    },
+  };
+
+  return { model, requests };
+}
+
+Deno.test("setConfigOption forwards arbitrary IDs and refreshes config options", async () => {
+  const { model, requests } = setupConfigOptionModel();
+
+  const response = await model.setConfigOption(
+    "agent-defined-id",
+    "agent-defined-value",
+  );
+
+  assertEquals(requests, [{
+    sessionId: "session-1",
+    configId: "agent-defined-id",
+    value: "agent-defined-value",
+  }]);
+  assertEquals(response.configOptions[0].currentValue, "high");
+  assertEquals(
+    model.getConfigOptions("thought_level")[0].currentValue,
+    "high",
+  );
+});
+
+Deno.test("setThoughtLevel resolves the agent-advertised config ID by category", async () => {
+  const { model, requests } = setupConfigOptionModel();
+
+  await model.setThoughtLevel("high");
+
+  assertEquals(requests, [{
+    sessionId: "session-1",
+    configId: "agent-specific-reasoning-id",
+    value: "high",
+  }]);
+  assertEquals(
+    model.getConfigOptions("_style")[0].id,
+    "agent-specific-style-id",
+  );
+});
+
+Deno.test("config option updates refresh the active session cache", () => {
+  const { model } = setupConfigOptionModel();
+  const updatedOption = {
+    ...model.getConfigOptions("thought_level")[0],
+    currentValue: "low",
+  };
+
+  (model as unknown as {
+    handleStreamNotification: (
+      controller: { enqueue: (_part: unknown) => void },
+      notification: unknown,
+    ) => void;
+  }).handleStreamNotification(
+    { enqueue: () => {} },
+    {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [updatedOption],
+      },
+    },
+  );
+
+  assertEquals(model.getConfigOptions(), [updatedOption]);
+});
+
+Deno.test("setConfigOptionByCategory rejects missing and ambiguous categories", async () => {
+  const { model } = setupConfigOptionModel();
+
+  await assertRejects(
+    () => model.setConfigOptionByCategory("model_config", "x"),
+    Error,
+    'No session config option is available for category "model_config".',
+  );
+
+  const options = model.getConfigOptions();
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [
+      ...options,
+      { ...options[0], id: "second-reasoning-id" },
+    ],
+  };
+
+  await assertRejects(
+    () => model.setThoughtLevel("low"),
+    Error,
+    "Multiple session config options are available",
+  );
 });
 
 /**


### PR DESCRIPTION
## Summary
Adds session config option support to `@mcpc/acp-ai-provider`, all targeting the currently active session:

- `setConfigOption(configId, value)` — set any agent-advertised option by its config ID
- `getConfigOptions(category?)` — read advertised options, optionally filtered by semantic category
- `setConfigOptionByCategory(category, value)` — set the single advertised option for a category; throws when none or multiple match
- `setThoughtLevel(value)` — shorthand resolving the option by the standard `thought_level` category
- Re-exports `SessionConfigOption`, `SessionConfigOptionCategory`, `SessionConfigValueId`, `SetSessionConfigOptionResponse`

Both `ACPProvider` and `ACPLanguageModel` expose these. Category matching never hard-codes agent-specific config IDs (CodeBuddy/Codex/Claude differ), and requires a unique match so ambiguous categories surface a clear error instead of guessing.

## Cache behavior
Local `configOptions` cache refreshes after every successful `setSessionConfigOption` and on incoming `config_option_update` session notifications (matched by session ID), since changing one option may affect others.

## Docs & tests
- Updated README section for models/modes/session config options
- Added 4 test groups covering arbitrary-ID forwarding, category-based ID resolution, notification-driven cache refresh, and missing/ambiguous category rejection

## Validation
- `deno fmt` + `deno check` (workspace build task) — pass
- `deno lint` on package — pass
- acp-ai-provider tests: 19 passed / 0 failed
- Full workspace test suite: 209 passed / 0 failed

No SDK bump: these APIs already exist in `@agentclientprotocol/sdk@^0.14.1`. The SDK 1.x model/mode → configOptions migration is intentionally left for a separate change to avoid breaking the existing `setModel`/`setMode` APIs.