### PR TITLE
fix(acp-ai-provider): support model/mode selection via session config options

### DIFF
--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -218,6 +218,27 @@ export class ACPAISDKClient implements Client {
 }
 
 /**
+ * Flattens the selectable values advertised by a `select` session config
+ * option into a plain value list (groups are expanded). Returns an empty
+ * array when the option does not enumerate concrete values.
+ */
+function flattenSessionConfigSelectValues(
+  option: SessionConfigOption,
+): string[] {
+  const values: string[] = [];
+  for (const entry of option.options) {
+    if ("group" in entry) {
+      for (const selectOption of entry.options) {
+        values.push(selectOption.value);
+      }
+    } else {
+      values.push(entry.value);
+    }
+  }
+  return values;
+}
+
+/**
  * Implements the AI SDK LanguageModelV2 interface for the
  * Agent Client Protocol (ACP).
  *
@@ -593,12 +614,14 @@ export class ACPLanguageModel implements LanguageModelV3 {
         // Treat as fresh since we are establishing a new session.
         this.isFreshSession = true;
 
+        await this.syncConfiguredModelAndMode();
         await this.applySessionDelay();
         return;
       }
 
       // If session already exists and we didn't just update it, do nothing
       if (this.sessionId) {
+        await this.syncConfiguredModelAndMode();
         return;
       }
 
@@ -626,31 +649,31 @@ export class ACPLanguageModel implements LanguageModelV3 {
         this.isFreshSession = true;
       }
 
-      // Init models/modes after session creation
-      const { models, modes } = this.sessionResponse ?? {};
-
-      if (models?.currentModelId) {
-        this.currentModelId = models.currentModelId;
-      }
-      if (modes?.currentModeId) {
-        this.currentModeId = modes.currentModeId;
-      }
-
-      // Update model if needed
-      if (this.modelId && this.modelId !== this.currentModelId) {
-        await this.setModel(this.modelId);
-        this.currentModelId = this.modelId;
-      }
-
-      // Update mode if needed
-      if (this.modeId && this.modeId !== this.currentModeId) {
-        await this.setMode(this.modeId);
-        this.currentModeId = this.modeId;
-      }
-
+      await this.syncConfiguredModelAndMode();
       await this.applySessionDelay();
     } catch (error) {
       throw toCatchableError(error, this.stderrChunks.join(""));
+    }
+  }
+
+  /**
+   * Resets model/mode state from the current session response and re-applies
+   * any configured model/mode. Resetting unconditionally prevents a stale
+   * currentModelId/currentModeId left over from a previous session from
+   * suppressing setModel()/setMode() after the session is re-created.
+   */
+  private async syncConfiguredModelAndMode(): Promise<void> {
+    const { models, modes } = this.sessionResponse ?? {};
+    this.currentModelId = models?.currentModelId ?? null;
+    this.currentModeId = modes?.currentModeId ?? null;
+
+    if (this.modelId && this.modelId !== this.currentModelId) {
+      await this.setModel(this.modelId);
+      this.currentModelId = this.modelId;
+    }
+    if (this.modeId && this.modeId !== this.currentModeId) {
+      await this.setMode(this.modeId);
+      this.currentModeId = this.modeId;
     }
   }
 
@@ -899,10 +922,39 @@ export class ACPLanguageModel implements LanguageModelV3 {
 
   /**
    * Sets the session model.
+   *
+   * Newer ACP agents advertise model selection through a session config
+   * option (category "model") instead of the legacy unstable models API.
+   * Prefer that config option when the agent advertises exactly one, and
+   * fall back to unstable_setSessionModel for agents that still expose
+   * `models` without a config option.
    */
   async setModel(modelId: string): Promise<void> {
     if (!this.connection || !this.sessionId) {
       throw new Error("Not connected. Call preconnect() first.");
+    }
+
+    const modelOptions = this.getConfigOptions("model");
+    if (modelOptions.length > 0) {
+      if (modelOptions.length > 1) {
+        const ids = modelOptions.map((option) => option.id).join(", ");
+        throw new Error(
+          `Multiple session config options are available for category "model": ${ids}. Use setConfigOption() with an explicit config ID.`,
+        );
+      }
+
+      const option = modelOptions[0];
+      const availableValues = flattenSessionConfigSelectValues(option);
+      if (availableValues.length > 0 && !availableValues.includes(modelId)) {
+        const availableList = availableValues.join(", ");
+        throw new Error(
+          `Model "${modelId}" is not available. Available models: ${availableList}`,
+        );
+      }
+
+      await this.setConfigOption(option.id, modelId);
+      this.currentModelId = modelId;
+      return;
     }
 
     const { models } = this.sessionResponse ?? {};
@@ -919,6 +971,10 @@ export class ACPLanguageModel implements LanguageModelV3 {
           `Model "${modelId}" is not available${currentInfo}. Available models: ${availableList}`,
         );
       }
+    } else if ((this.sessionResponse?.configOptions?.length ?? 0) > 0) {
+      throw new Error(
+        `Model "${modelId}" cannot be applied: the agent advertises session config options but no model option with category "model". Inspect getConfigOptions() and call setConfigOption() with the intended config ID.`,
+      );
     }
 
     await this.connection.unstable_setSessionModel({

--- a/packages/acp-ai-provider/src/language-model.ts
+++ b/packages/acp-ai-provider/src/language-model.ts
@@ -895,10 +895,39 @@ export class ACPLanguageModel implements LanguageModelV3 {
 
   /**
    * Sets the session mode (e.g., "ask", "plan").
+   *
+   * Agents built purely on session config options advertise mode selection
+   * through a config option (category "mode") instead of the session modes
+   * API. Prefer that config option when the agent advertises exactly one,
+   * and fall back to the stable session modes API (setSessionMode) for
+   * agents that expose `modes` without a config option.
    */
   async setMode(modeId: string): Promise<void> {
     if (!this.connection || !this.sessionId) {
       throw new Error("Not connected. Call preconnect() first.");
+    }
+
+    const modeOptions = this.getConfigOptions("mode");
+    if (modeOptions.length > 0) {
+      if (modeOptions.length > 1) {
+        const ids = modeOptions.map((option) => option.id).join(", ");
+        throw new Error(
+          `Multiple session config options are available for category "mode": ${ids}. Use setConfigOption() with an explicit config ID.`,
+        );
+      }
+
+      const option = modeOptions[0];
+      const availableValues = flattenSessionConfigSelectValues(option);
+      if (availableValues.length > 0 && !availableValues.includes(modeId)) {
+        const availableList = availableValues.join(", ");
+        throw new Error(
+          `Mode "${modeId}" is not available. Available modes: ${availableList}`,
+        );
+      }
+
+      await this.setConfigOption(option.id, modeId);
+      this.currentModeId = modeId;
+      return;
     }
 
     const availableModes = this.sessionResponse?.modes?.availableModes;
@@ -914,6 +943,10 @@ export class ACPLanguageModel implements LanguageModelV3 {
           `Mode "${modeId}" is not available${currentInfo}. Available modes: ${availableList}`,
         );
       }
+    } else if ((this.sessionResponse?.configOptions?.length ?? 0) > 0) {
+      throw new Error(
+        `Mode "${modeId}" cannot be applied: the agent advertises session config options but no mode option with category "mode". Inspect getConfigOptions() and call setConfigOption() with the intended config ID.`,
+      );
     }
 
     await this.connection.setSessionMode({ sessionId: this.sessionId, modeId });

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -238,6 +238,233 @@ Deno.test("setConfigOptionByCategory rejects missing and ambiguous categories", 
   );
 });
 
+function createModelConfigOption(currentValue: string) {
+  return {
+    id: "model",
+    name: "Model",
+    category: "model",
+    type: "select" as const,
+    currentValue,
+    options: [
+      { value: "gemini-3.7-flash-high", name: "High" },
+      { value: "gemini-3.7-flash", name: "Standard" },
+    ],
+  };
+}
+
+Deno.test("setModel routes through the agent's session config option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modelOption = createModelConfigOption("gemini-3.7-flash-high");
+  const requests: unknown[] = [];
+  let legacyCalled = false;
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [modelOption],
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: (request: unknown) => {
+      requests.push(request);
+      return Promise.resolve({
+        configOptions: [
+          {
+            ...modelOption,
+            currentValue: (request as { value: string }).value,
+          },
+        ],
+      });
+    },
+    unstable_setSessionModel: () => {
+      legacyCalled = true;
+      return Promise.resolve({});
+    },
+  };
+
+  await model.setModel("gemini-3.7-flash");
+
+  assertEquals(requests, [{
+    sessionId: "session-1",
+    configId: "model",
+    value: "gemini-3.7-flash",
+  }]);
+  assertEquals(legacyCalled, false);
+  assertEquals(
+    model.getConfigOptions("model")[0].currentValue,
+    "gemini-3.7-flash",
+  );
+});
+
+Deno.test("setModel validates the value against the advertised model option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modelOption = createModelConfigOption("gemini-3.7-flash-high");
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [modelOption],
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: () =>
+      Promise.resolve({ configOptions: [modelOption] }),
+  };
+
+  await assertRejects(
+    () => model.setModel("gemini-4"),
+    Error,
+    "is not available",
+  );
+});
+
+Deno.test("setModel falls back to the legacy model API without a model config option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const requests: unknown[] = [];
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    models: {
+      availableModels: [{ modelId: "opus" }, { modelId: "haiku" }],
+      currentModelId: "opus",
+    },
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    unstable_setSessionModel: (request: unknown) => {
+      requests.push(request);
+      return Promise.resolve({});
+    },
+  };
+
+  await model.setModel("haiku");
+
+  assertEquals(requests, [{
+    sessionId: "session-1",
+    modelId: "haiku",
+  }]);
+
+  await assertRejects(
+    () => model.setModel("claude"),
+    Error,
+    "is not available",
+  );
+});
+
+Deno.test("setModel rejects ambiguous or missing model config options", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modelOption = createModelConfigOption("gemini-3.7-flash-high");
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: () =>
+      Promise.resolve({ configOptions: [modelOption] }),
+  };
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [
+      modelOption,
+      { ...modelOption, id: "secondary-model" },
+    ],
+  };
+
+  await assertRejects(
+    () => model.setModel("gemini-3.7-flash"),
+    Error,
+    'Multiple session config options are available for category "model"',
+  );
+
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [
+      {
+        id: "style",
+        name: "Style",
+        category: "_style",
+        type: "select",
+        currentValue: "concise",
+        options: [{ value: "concise", name: "Concise" }],
+      },
+    ],
+  };
+
+  await assertRejects(
+    () => model.setModel("gemini-3.7-flash"),
+    Error,
+    'no model option with category "model"',
+  );
+});
+
+Deno.test("startSession re-applies the configured model after session re-creation", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  model.modelId = "gemini-3.7-flash";
+  const modelOption = createModelConfigOption("gemini-3.7-flash-high");
+  const requests: unknown[] = [];
+  let sessionCounter = 0;
+
+  (model as unknown as { connection: unknown }).connection = {
+    newSession: () => {
+      sessionCounter += 1;
+      return Promise.resolve({
+        sessionId: `session-${sessionCounter}`,
+        configOptions: [modelOption],
+      });
+    },
+    setSessionConfigOption: (request: unknown) => {
+      requests.push(request);
+      return Promise.resolve({
+        configOptions: [
+          {
+            ...modelOption,
+            currentValue: (request as { value: string }).value,
+          },
+        ],
+      });
+    },
+  };
+
+  await model.startSession();
+  assertEquals(requests.length, 1);
+
+  // Simulate a cleanup that drops the session but leaves a stale model state.
+  (model as unknown as { sessionId: string | null }).sessionId = null;
+  (model as unknown as { currentModelId: string | null }).currentModelId =
+    "gemini-3.7-flash";
+
+  await model.startSession();
+
+  assertEquals(requests, [
+    {
+      sessionId: "session-1",
+      configId: "model",
+      value: "gemini-3.7-flash",
+    },
+    {
+      sessionId: "session-2",
+      configId: "model",
+      value: "gemini-3.7-flash",
+    },
+  ]);
+});
+
 /**
  * Helpers for abort/cancel tests: stubs the ACP internals so we can drive
  * prompt resolution and observe session/cancel + prompt ordering.

--- a/packages/acp-ai-provider/tests/language-model.test.ts
+++ b/packages/acp-ai-provider/tests/language-model.test.ts
@@ -252,6 +252,20 @@ function createModelConfigOption(currentValue: string) {
   };
 }
 
+function createModeConfigOption(currentValue: string) {
+  return {
+    id: "mode",
+    name: "Mode",
+    category: "mode",
+    type: "select" as const,
+    currentValue,
+    options: [
+      { value: "default", name: "Default" },
+      { value: "plan", name: "Plan" },
+    ],
+  };
+}
+
 Deno.test("setModel routes through the agent's session config option", async () => {
   const model = new ACPLanguageModel(
     "test-agent",
@@ -406,6 +420,160 @@ Deno.test("setModel rejects ambiguous or missing model config options", async ()
     () => model.setModel("gemini-3.7-flash"),
     Error,
     'no model option with category "model"',
+  );
+});
+
+Deno.test("setMode routes through the agent's session config option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modeOption = createModeConfigOption("default");
+  const configRequests: unknown[] = [];
+  const modeRequests: unknown[] = [];
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [modeOption],
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: (request: unknown) => {
+      configRequests.push(request);
+      return Promise.resolve({
+        configOptions: [
+          { ...modeOption, currentValue: (request as { value: string }).value },
+        ],
+      });
+    },
+    setSessionMode: (request: unknown) => {
+      modeRequests.push(request);
+      return Promise.resolve({});
+    },
+  };
+
+  await model.setMode("plan");
+
+  assertEquals(configRequests, [{
+    sessionId: "session-1",
+    configId: "mode",
+    value: "plan",
+  }]);
+  assertEquals(modeRequests, []);
+  assertEquals(
+    model.getConfigOptions("mode")[0].currentValue,
+    "plan",
+  );
+});
+
+Deno.test("setMode validates the value against the advertised mode option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modeOption = createModeConfigOption("default");
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [modeOption],
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: () =>
+      Promise.resolve({ configOptions: [modeOption] }),
+  };
+
+  await assertRejects(
+    () => model.setMode("ask"),
+    Error,
+    "is not available",
+  );
+});
+
+Deno.test("setMode falls back to the session modes API without a mode config option", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const requests: unknown[] = [];
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    modes: {
+      availableModes: [{ id: "default" }, { id: "plan" }],
+      currentModeId: "default",
+    },
+  };
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionMode: (request: unknown) => {
+      requests.push(request);
+      return Promise.resolve({});
+    },
+  };
+
+  await model.setMode("plan");
+
+  assertEquals(requests, [{
+    sessionId: "session-1",
+    modeId: "plan",
+  }]);
+
+  await assertRejects(
+    () => model.setMode("ask"),
+    Error,
+    "is not available",
+  );
+});
+
+Deno.test("setMode rejects ambiguous or missing mode config options", async () => {
+  const model = new ACPLanguageModel(
+    "test-agent",
+    undefined,
+    createProviderSettings(),
+  );
+  const modeOption = createModeConfigOption("default");
+
+  (model as unknown as { sessionId: string }).sessionId = "session-1";
+  (model as unknown as { connection: unknown }).connection = {
+    setSessionConfigOption: () =>
+      Promise.resolve({ configOptions: [modeOption] }),
+  };
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [
+      modeOption,
+      { ...modeOption, id: "secondary-mode" },
+    ],
+  };
+
+  await assertRejects(
+    () => model.setMode("plan"),
+    Error,
+    'Multiple session config options are available for category "mode"',
+  );
+
+  (model as unknown as { sessionResponse: unknown }).sessionResponse = {
+    sessionId: "session-1",
+    configOptions: [
+      {
+        id: "style",
+        name: "Style",
+        category: "_style",
+        type: "select",
+        currentValue: "concise",
+        options: [{ value: "concise", name: "Concise" }],
+      },
+    ],
+  };
+
+  await assertRejects(
+    () => model.setMode("plan"),
+    Error,
+    'no mode option with category "mode"',
   );
 });
 


### PR DESCRIPTION
Fixes #61

## Problem
Agents that expose model/mode selection through **session config options** (stable `session/set_config_option`) instead of the legacy model/mode APIs broke selection in two ways:

1. `setModel()` unconditionally called the unstable `unstable_setSessionModel` → `"Method not found": session/set_model` crash. `setMode()` similarly only knew the session modes RPC, so config-option-only agents (`category: "mode"`) would crash with `"Method not found": session/set_mode`.
2. `startSession()` only synced `currentModelId` when the legacy `models` field existed, so on session re-creation a stale value suppressed `setModel()` on the new session (silently ran the agent default). Two spots also assigned the mode id to `currentModelId`.

## Changes
`packages/acp-ai-provider/src/language-model.ts`
- `setModel(modelId)` now prefers the agent's session config option with category `"model"` (via stable `setSessionConfigOption`), validating against the option's advertised values where available. Falls back to legacy `unstable_setSessionModel` only when the agent exposes `models` without a model config option.
- `setMode(modeId)` is now symmetrical: prefers the `category: "mode"` config option via `setSessionConfigOption`, falls back to the stable session modes API (`setSessionMode`) when the agent exposes `modes` without a mode config option.
- Multiple options for a category throw with explicit config IDs (use `setConfigOption(id, value)`); agents advertising config options but no model/mode option fail with actionable errors instead of crashing.
- New `syncConfiguredModelAndMode()` resets `currentModelId`/`currentModeId` from each session response and re-applies the configured model/mode. It runs after every session (re)creation, including the two early-return paths that previously skipped sync entirely.
- Fixed the mode-id-to-`currentModelId` misassignments.

## Tests
Added 9 tests in `language-model.test.ts`:
- `setModel` / `setMode` route through their config option (and never call the legacy/stable RPC)
- `setModel` / `setMode` validate against advertised option values
- `setModel` / `setMode` fall back to the legacy/stable API when no config option exists
- `setModel` / `setMode` reject ambiguous / missing config options with guidance
- `startSession` re-applies the configured model after session re-creation (stale `currentModelId`)

## Validation
- acp-ai-provider tests: 28 passed / 0 failed
- `deno lint`, `deno fmt --check`, workspace `deno check` — pass